### PR TITLE
chore: use gpt-4o instead of gpt-4-turbo

### DIFF
--- a/src/01-function-calling/index.ts
+++ b/src/01-function-calling/index.ts
@@ -111,7 +111,7 @@ async function main() {
    */
 
   const response = await openai.chat.completions.create({
-    model: "gpt-3.5-turbo",
+    model: "gpt-4o",
     temperature: 0,
     messages,
     tools,
@@ -145,7 +145,7 @@ async function main() {
 
     if (artists) {
       const response = await openai.chat.completions.create({
-        model: "gpt-3.5-turbo",
+        model: "gpt-4o",
         temperature: 0,
         messages: [
           {

--- a/src/02-assistant/index.ts
+++ b/src/02-assistant/index.ts
@@ -102,7 +102,7 @@ async function main() {
       name: "Artsy Advisor",
       instructions:
         "You are an art advisor. Your job is to listen to your client and provide helpful recommendations of artworks and artists that they may like. You consider price range, medium, rarity, and other key attributes a client may want to consider when purchasing art. You ask clarifying questions where necessary to build an accurate profile on your client and provide more accurate recommendations.",
-      model: "gpt-3.5-turbo",
+      model: "gpt-4o",
       tools,
     })
   }

--- a/src/03-express-streaming/server.ts
+++ b/src/03-express-streaming/server.ts
@@ -84,7 +84,7 @@ app.post("/", async (req: Request, res: Response) => {
     console.log("Received request:", req.headers)
 
     const stream = openai.beta.chat.completions.stream({
-      model: "gpt-3.5-turbo",
+      model: "gpt-4o",
       stream: true,
       messages: [
         {

--- a/src/04-express/server.ts
+++ b/src/04-express/server.ts
@@ -72,7 +72,7 @@ app.post("/", async (req: Request, res: Response) => {
 
     const response = await openai.chat.completions.create({
       messages: JSON.parse(req.body),
-      model: "gpt-3.5-turbo",
+      model: "gpt-4o",
       tools,
     })
 
@@ -99,7 +99,7 @@ app.post("/", async (req: Request, res: Response) => {
       let generatedResponse
       if (profile) {
         const responseFromTools = await openai.chat.completions.create({
-          model: "gpt-3.5-turbo",
+          model: "gpt-4o",
           temperature: 0,
           messages: [
             {

--- a/src/05-instruction-experiments/server.ts
+++ b/src/05-instruction-experiments/server.ts
@@ -65,7 +65,7 @@ app.post("/", async (req: Request, res: Response) => {
     const response = await openai.chat.completions.create({
       // NOTE: client is unaware of the system message since we don't append it to the messages array.
       messages: [{ role: "system", content: instructions }, ...messages],
-      model: "gpt-4-turbo",
+      model: "gpt-4o",
       tools,
     })
 
@@ -122,7 +122,7 @@ app.post("/", async (req: Request, res: Response) => {
 
       // get a second response including the function response(s) in the messages.
       const secondResponse = await openai.chat.completions.create({
-        model: "gpt-4-turbo",
+        model: "gpt-4o",
         messages: messages,
       })
 

--- a/src/08-recommendations/01-index.ts
+++ b/src/08-recommendations/01-index.ts
@@ -36,7 +36,7 @@ async function main() {
 
   const response = await openai.chat.completions.create({
     messages: messages,
-    model: "gpt-4-turbo",
+    model: "gpt-4o",
     temperature: 0,
   })
 

--- a/src/08-recommendations/02-index.ts
+++ b/src/08-recommendations/02-index.ts
@@ -61,7 +61,7 @@ async function main() {
           ),
         },
       ],
-      model: "gpt-4-turbo",
+      model: "gpt-4o",
       temperature: 1,
     })
 
@@ -85,7 +85,7 @@ async function main() {
         content: userMessageContent(userDescription, finalCandidateList),
       },
     ],
-    model: "gpt-4-turbo",
+    model: "gpt-4o",
     temperature: 1,
   })
 


### PR DESCRIPTION
As [discussed](https://github.com/artsy/quantum/pull/9#discussion_r1602071102) , lets use the newly released`gpt-40` instead of `gpt-4-turbo` and take advantage of its improved performance and cost. 