### PR TITLE
feat: adds 12-fine-tuning to customize a fine-tuned model for inferring artwork mediums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ src/10-tone-voice/**/*.zip
 
 # brushy cli
 src/11-brushy-cli/**/*.txt
+
+# fine-tuning mediums
+src/12-fine-tuning/data/training/*
+!src/12-fine-tuning/data/training/.gitkeep

--- a/src/12-fine-tuning/01-medium.ts
+++ b/src/12-fine-tuning/01-medium.ts
@@ -1,11 +1,13 @@
 import { prepareData } from "./lib/data"
 import { uploadData } from "./lib/file"
+import { submitFineTuneJob } from "./lib/fine-tune"
 
 export const SELECTED_INPUT = "medium-sample-100"
 
 async function main() {
   await prepareData()
-  await uploadData()
+  const uploadedFiles = await uploadData()
+  await submitFineTuneJob(uploadedFiles)
 }
 
 main()

--- a/src/12-fine-tuning/01-medium.ts
+++ b/src/12-fine-tuning/01-medium.ts
@@ -5,6 +5,16 @@ import { assessFineTune, summarizeResults } from "./lib/test"
 
 export const SELECTED_INPUT = "medium-sample-100"
 
+/**
+ * Adds a script to create a fine-tuned model for inferring artwork mediums from their materials descriptions
+ *
+ * yarn tsx src/12-fine-tuning/01-medium.ts
+ *
+ * This will generate properly formatted training data, upload it, and kick off a fine-tuning job.
+ *
+ * Once it completes, it will send it some test data and print out the results.
+ */
+
 async function main() {
   await prepareData()
   const uploadedFiles = await uploadData()

--- a/src/12-fine-tuning/01-medium.ts
+++ b/src/12-fine-tuning/01-medium.ts
@@ -1,0 +1,9 @@
+import { prepareData } from "./lib/data"
+
+export const SELECTED_INPUT = "medium-sample-100"
+
+async function main() {
+  await prepareData()
+}
+
+main()

--- a/src/12-fine-tuning/01-medium.ts
+++ b/src/12-fine-tuning/01-medium.ts
@@ -1,13 +1,16 @@
 import { prepareData } from "./lib/data"
 import { uploadData } from "./lib/file"
 import { submitFineTuneJob } from "./lib/fine-tune"
+import { assessFineTune, summarizeResults } from "./lib/test"
 
 export const SELECTED_INPUT = "medium-sample-100"
 
 async function main() {
   await prepareData()
   const uploadedFiles = await uploadData()
-  await submitFineTuneJob(uploadedFiles)
+  const fineTune = await submitFineTuneJob(uploadedFiles)
+  const results = await assessFineTune({ modelId: fineTune.fine_tuned_model! })
+  summarizeResults(results)
 }
 
 main()

--- a/src/12-fine-tuning/01-medium.ts
+++ b/src/12-fine-tuning/01-medium.ts
@@ -1,9 +1,11 @@
 import { prepareData } from "./lib/data"
+import { uploadData } from "./lib/file"
 
 export const SELECTED_INPUT = "medium-sample-100"
 
 async function main() {
   await prepareData()
+  await uploadData()
 }
 
 main()

--- a/src/12-fine-tuning/data/raw/medium-sample-100.jsonl
+++ b/src/12-fine-tuning/data/raw/medium-sample-100.jsonl
@@ -1,0 +1,100 @@
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic on cardboard applied on canvas" }
+{ "category": "Painting", "medium": "Tempera on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil on paper"}
+{ "category": "Print", "medium": "Offset lithograph in colours, on Arches paper, the full sheet."}
+{ "category": "Painting", "medium": "Pencil on paper" }
+{ "category": "Mixed Media", "medium": "Photography, oil, ink and pastel with textured matte surface on birch panel."}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Photography", "medium": "Silver gelatin print" }
+{ "category": "Print", "medium": "Screenprint in colors on wove paper" }
+{ "category": "Painting", "medium": "Oil on Wood" }
+{ "category": "Painting", "medium": "Acrylic and Oil on Canvas" }
+{ "category": "Mixed Media", "medium": "Wool on wood" }
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media on paper"}
+{ "category": "Painting", "medium": "Acrylic, charcoal on Cotton canvas" }
+{ "category": "Sculpture", "medium": "Murano Glass Casting" }
+{ "category": "Painting", "medium": "Oil pastel on paper" }
+{ "category": "Photography", "medium": "Light and magenta ink on Hahnemühle Photo Rag paper 43 hour exposure"}
+{ "category": "Photography", "medium": "Hahnemühle German etching on dibond"}
+{ "category": "Print", "medium": "Etching and Aquatint" }
+{ "category": "Painting", "medium": "Encaustic on wood" }
+{ "category": "Sculpture", "medium": "Ink, paint, on aluminum" }
+{ "category": "Painting", "medium": "Acrylic & archival pigment on Hanhemuhle Museum etching paper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Oil pastels on paper"}
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Acrylic on paper"}
+{ "category": "Design/Decorative Art", "medium": "Prima Spinneybeck leather, chrome frame"}
+{ "category": "Painting", "medium": "Acrylic on mixed media" }
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Acrylic on Paper" }
+{ "category": "Painting", "medium": "Oil stick on jute" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Sculpture", "medium": "Minerals glued onto plywood panel" }
+{ "category": "Painting", "medium": "Spray paint and acrylic pen on newspaper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Colored pencil on paper"}
+{ "category": "Sculpture", "medium": "Ceramic & glaze" }
+{ "category": "Painting", "medium": "Acrylic on wooden panel" }
+{ "category": "Print", "medium": "Ink on paper" }
+{ "category": "Print", "medium": "Screenprint in colors" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Acrylic on paper"}
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Photography", "medium": "Archival Pigment Print" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic painting on a heavy weight professional paper"}
+{ "category": "Painting", "medium": "Mineral pigment, Dyed mud pigment" }
+{ "category": "Painting", "medium": "Mixed, acrylic and spray on canvas, framed in neón orange acrylic"}
+{ "category": "Painting", "medium": "Charcoal, pencil and African wax on cardboard"}
+{ "category": "Print", "medium": "Digital impression on pumice stone" }
+{ "category": "Painting", "medium": "Oil and 24k gold leaf on panel" }
+{ "category": "Painting", "medium": "Oil on Wood" }
+{ "category": "Sculpture", "medium": "Stoneware" }
+{ "category": "Print", "medium": "Etching in colors" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil on ivory-colored paper"}
+{ "category": "Print", "medium": "Lithograph" }
+{ "category": "Print", "medium": "Soft-ground etching and aquatint with Gampi chine colle on Hahnemuhle Copperplate"}
+{ "category": "Print", "medium": "Screenprint on Gemini Rag Board" }
+{ "category": "Mixed Media", "medium": "Silkscreen and Mixed Media on Paper"}
+{ "category": "Sculpture", "medium": "Mixed media" }
+{ "category": "Sculpture", "medium": "Wood, paint and plaster" }
+{ "category": "Print", "medium": "Archival pigment print" }
+{ "category": "Sculpture", "medium": "Slip cast porcelain and glass rods" }
+{ "category": "Painting", "medium": "Acrylic on paper" }
+{ "category": "Sculpture", "medium": "Ceramic" }
+{ "category": "Painting", "medium": "Oil on Linen" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic on anodized aluminum" }
+{ "category": "Print", "medium": "Lithograph" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil, Fineliner and Copic markers"}
+{ "category": "Photography", "medium": "Silver Gelatin Photograph inscribed with Ink and Collage"}
+{ "category": "Sculpture", "medium": "Glazed ceramic" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Mixed media. Reverse painting on Plexiglas."}
+{ "category": "Print", "medium": "C-Print on Kodak Paper" }
+{ "category": "Painting", "medium": "Dibond, canvas, plaster, ink spray paint and paintmarker, hand-embellished"}
+{ "category": "Print", "medium": "Archival pigment print + silkscreen" }
+{ "category": "Painting", "medium": "Mixed Media" }
+{ "category": "Painting", "medium": "Acrylique aérosol paper on canvas" }
+{ "category": "Sculpture", "medium": "Painted stainless steel and aluminum" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Gouache sur papier" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Sculpture", "medium": "Stainless steel, painted wood" }
+{ "category": "Print", "medium": "Screenprint in colors on Cream Speckletone paper"}
+{ "category": "Photography", "medium": "Pigment transfer on polylaminate" }
+{ "category": "Painting", "medium": "Oil on board, gold frame" }
+{ "category": "Painting", "medium": "Canvas, Acrylic, pen, paper, pencil" }
+{ "category": "Print", "medium": "BASF Luran" }
+{ "category": "Mixed Media", "medium": "Archival pigment print with polymer on Washi paper"}
+{ "category": "Other", "medium": "Ceramic" }
+{ "category": "Print", "medium": "Offset lithograph in colors on wove paper"}
+{ "category": "Other", "medium": "Glass" }
+{ "category": "Print", "medium": "Lithograph in colors with collage and embossing on Arches"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Gloss paint on board" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }

--- a/src/12-fine-tuning/data/raw/medium-sample-1000.jsonl
+++ b/src/12-fine-tuning/data/raw/medium-sample-1000.jsonl
@@ -1,0 +1,1000 @@
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic on cardboard applied on canvas" }
+{ "category": "Painting", "medium": "Tempera on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil on paper"}
+{ "category": "Print", "medium": "Offset lithograph in colours, on Arches paper, the full sheet."}
+{ "category": "Painting", "medium": "Pencil on paper" }
+{ "category": "Mixed Media", "medium": "Photography, oil, ink and pastel with textured matte surface on birch panel."}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Photography", "medium": "Silver gelatin print" }
+{ "category": "Print", "medium": "Screenprint in colors on wove paper" }
+{ "category": "Painting", "medium": "Oil on Wood" }
+{ "category": "Painting", "medium": "Acrylic and Oil on Canvas" }
+{ "category": "Mixed Media", "medium": "Wool on wood" }
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media on paper"}
+{ "category": "Painting", "medium": "Acrylic, charcoal on Cotton canvas" }
+{ "category": "Sculpture", "medium": "Murano Glass Casting" }
+{ "category": "Painting", "medium": "Oil pastel on paper" }
+{ "category": "Photography", "medium": "Light and magenta ink on Hahnemühle Photo Rag paper 43 hour exposure"}
+{ "category": "Photography", "medium": "Hahnemühle German etching on dibond"}
+{ "category": "Print", "medium": "Etching and Aquatint" }
+{ "category": "Painting", "medium": "Encaustic on wood" }
+{ "category": "Sculpture", "medium": "Ink, paint, on aluminum" }
+{ "category": "Painting", "medium": "Acrylic & archival pigment on Hanhemuhle Museum etching paper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Oil pastels on paper"}
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Acrylic on paper"}
+{ "category": "Design/Decorative Art", "medium": "Prima Spinneybeck leather, chrome frame"}
+{ "category": "Painting", "medium": "Acrylic on mixed media" }
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Acrylic on Paper" }
+{ "category": "Painting", "medium": "Oil stick on jute" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Sculpture", "medium": "Minerals glued onto plywood panel" }
+{ "category": "Painting", "medium": "Spray paint and acrylic pen on newspaper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Colored pencil on paper"}
+{ "category": "Sculpture", "medium": "Ceramic & glaze" }
+{ "category": "Painting", "medium": "Acrylic on wooden panel" }
+{ "category": "Print", "medium": "Ink on paper" }
+{ "category": "Print", "medium": "Screenprint in colors" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Acrylic on paper"}
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Photography", "medium": "Archival Pigment Print" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic painting on a heavy weight professional paper"}
+{ "category": "Painting", "medium": "Mineral pigment, Dyed mud pigment" }
+{ "category": "Painting", "medium": "Mixed, acrylic and spray on canvas, framed in neón orange acrylic"}
+{ "category": "Painting", "medium": "Charcoal, pencil and African wax on cardboard"}
+{ "category": "Print", "medium": "Digital impression on pumice stone" }
+{ "category": "Painting", "medium": "Oil and 24k gold leaf on panel" }
+{ "category": "Painting", "medium": "Oil on Wood" }
+{ "category": "Sculpture", "medium": "Stoneware" }
+{ "category": "Print", "medium": "Etching in colors" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil on ivory-colored paper"}
+{ "category": "Print", "medium": "Lithograph" }
+{ "category": "Print", "medium": "Soft-ground etching and aquatint with Gampi chine colle on Hahnemuhle Copperplate"}
+{ "category": "Print", "medium": "Screenprint on Gemini Rag Board" }
+{ "category": "Mixed Media", "medium": "Silkscreen and Mixed Media on Paper"}
+{ "category": "Sculpture", "medium": "Mixed media" }
+{ "category": "Sculpture", "medium": "Wood, paint and plaster" }
+{ "category": "Print", "medium": "Archival pigment print" }
+{ "category": "Sculpture", "medium": "Slip cast porcelain and glass rods" }
+{ "category": "Painting", "medium": "Acrylic on paper" }
+{ "category": "Sculpture", "medium": "Ceramic" }
+{ "category": "Painting", "medium": "Oil on Linen" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic on anodized aluminum" }
+{ "category": "Print", "medium": "Lithograph" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil, Fineliner and Copic markers"}
+{ "category": "Photography", "medium": "Silver Gelatin Photograph inscribed with Ink and Collage"}
+{ "category": "Sculpture", "medium": "Glazed ceramic" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Mixed media. Reverse painting on Plexiglas."}
+{ "category": "Print", "medium": "C-Print on Kodak Paper" }
+{ "category": "Painting", "medium": "Dibond, canvas, plaster, ink spray paint and paintmarker, hand-embellished"}
+{ "category": "Print", "medium": "Archival pigment print + silkscreen" }
+{ "category": "Painting", "medium": "Mixed Media" }
+{ "category": "Painting", "medium": "Acrylique aérosol paper on canvas" }
+{ "category": "Sculpture", "medium": "Painted stainless steel and aluminum" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Gouache sur papier" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Sculpture", "medium": "Stainless steel, painted wood" }
+{ "category": "Print", "medium": "Screenprint in colors on Cream Speckletone paper"}
+{ "category": "Photography", "medium": "Pigment transfer on polylaminate" }
+{ "category": "Painting", "medium": "Oil on board, gold frame" }
+{ "category": "Painting", "medium": "Canvas, Acrylic, pen, paper, pencil" }
+{ "category": "Print", "medium": "BASF Luran" }
+{ "category": "Mixed Media", "medium": "Archival pigment print with polymer on Washi paper"}
+{ "category": "Other", "medium": "Ceramic" }
+{ "category": "Print", "medium": "Offset lithograph in colors on wove paper"}
+{ "category": "Other", "medium": "Glass" }
+{ "category": "Print", "medium": "Lithograph in colors with collage and embossing on Arches"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Gloss paint on board" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic on hardboard panels" }
+{ "category": "Painting", "medium": "Oil on panel" }
+{ "category": "Mixed Media", "medium": "Assembly, painting, wood, cotton thread, paper on board"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Mixed Media", "medium": "Wood" }
+{ "category": "Print", "medium": "Multiple, double screen printing on transparent PVC and cardboard"}
+{ "category": "Textile Arts", "medium": "Yarns of wool and Maguey fiber" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media on paper"}
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Painting", "medium": "Oil, Acrylic on canvas" }
+{ "category": "Painting", "medium": "Frottage and drawings with graphite on paper; wool, silk thread, paper cut out, graphite"}
+{ "category": "Sculpture", "medium": "Acrylic on epoxy" }
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Sculpture", "medium": "Reptile water bowl and accumulated material"}
+{ "category": "Reproduction", "medium": "Color lithograph on Arjomari wove paper"}
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Painting", "medium": "Óleo sobra tela" }
+{ "category": "Photography", "medium": "Silver Gelatin Contact Print" }
+{ "category": "Print", "medium": "13 colour screenprint on Somerset Satin Tub sized 410 gsm"}
+{ "category": "Painting", "medium": "Oil paint on cotton paper" }
+{ "category": "Print", "medium": "Original Color Lithograph" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil on ivory-colored paper"}
+{ "category": "Painting", "medium": "Collage Korean rice paper (Hanji) and oil on canvas"}
+{ "category": "Print", "medium": "Etching" }
+{ "category": "Photography", "medium": "Archival Pigment Print" }
+{ "category": "Painting", "medium": "Oil on panel" }
+{ "category": "Photography", "medium": "Photography" }
+{ "category": "Photography", "medium": "Photography on Rag Baryta Paper" }
+{ "category": "Painting", "medium": "Acrylic, epoxy resin, LED lights, glitter and holographic vinyl on wood cat head panel"}
+{ "category": "Print", "medium": "C-Print on Kodak Paper" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Oleo sobre tela" }
+{ "category": "Print", "medium": "Screenprint in colors on wove paper" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Oil, spray, flashe and acrylic on canvas"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Graphite on paper mounted on wood"}
+{ "category": "Print", "medium": "Color Lithographs on B.F.K. Rives paper" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Charcoal ivory-colored paper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil on ivory-colored paper"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Sculpture", "medium": "Bronze" }
+{ "category": "Mixed Media", "medium": "Crystal, mixed assembly" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil painting" }
+{ "category": "Sculpture", "medium": "Bronze" }
+{ "category": "Painting", "medium": "Oil on linen canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Acrylic ink and paint on paper"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil ivory-colored paper."}
+{ "category": "Painting", "medium": "Oil and sand on canvas" }
+{ "category": "Print", "medium": "Screenprint in colors on Fedrigoni Old Mill paper"}
+{ "category": "Sculpture", "medium": "Fully polished stainless steel" }
+{ "category": "Mixed Media", "medium": "Wool on wood" }
+{ "category": "Print", "medium": "Silkscreen in 78 colors on cardboard, shaped and mounted on corrugate cardboard"}
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Ephemera or Merchandise", "medium": "Vinyl Figure" }
+{ "category": "Photography", "medium": "Hahnemuhle  Photo Rag Paper" }
+{ "category": "Print", "medium": "Archival pigment printing" }
+{ "category": "Painting", "medium": "Acrylic on panel" }
+{ "category": "Painting", "medium": "Oil on paper, mounted on wood panel" }
+{ "category": "Photography", "medium": "Silver gelatin print" }
+{ "category": "Print", "medium": "Original Lithograph" }
+{ "category": "Photography", "medium": "Archival pigment print" }
+{ "category": "Textile Arts", "medium": "Tejido con robot. Lana" }
+{ "category": "Painting", "medium": "Mixed media on linen" }
+{ "category": "Sculpture", "medium": "Cast glass, stoneware, gold leaf, crystal gemstones"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Print", "medium": "Screenprint in colors" }
+{ "category": "Sculpture", "medium": "Limewood & Acrylic" }
+{ "category": "Painting", "medium": "INDUSTRIAL PAINT MARKER WITH WATERPROOF VARNISH ON CANVAS"}
+{ "category": "Print", "medium": "Lithograph and silkscreen on paper" }
+{ "category": "Mixed Media", "medium": "Assembly of wasted materials such as plastic and others"}
+{ "category": "Print", "medium": "Lithograph in colors" }
+{ "category": "Painting", "medium": "Préparation polymérique, encre, peinture acrylique, peinture vinylique, pigment, mica et résine sur tissu"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil on paper"}
+{ "category": "Painting", "medium": "Acrylic enamel on paper" }
+{ "category": "Painting", "medium": "Technique mixte sur dibond" }
+{ "category": "Print", "medium": "Offset lithograph in colors" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Mixed Media on Canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Ephemera or Merchandise", "medium": "8oz. glass tumbler with chrome-painted rising Shark."}
+{ "category": "Painting", "medium": "Flattened Corrugated Iron" }
+{ "category": "Painting", "medium": "Oil & Wax on Board" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Watercolor on paper"}
+{ "category": "Painting", "medium": "Mixed media" }
+{ "category": "Painting", "medium": "Acrílico sobre tela" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pulled paper"}
+{ "category": "Reproduction", "medium": "Color lithograph on Arjomari wove paper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Ink, colored pencil and graphite on paper"}
+{ "category": "Sculpture", "medium": "Foraged white Quartz from Nirox Foundation at the cradle of human kind, South Africa"}
+{ "category": "Painting", "medium": "Watercolor" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Other", "medium": "AI generated text-to-image poems, printed on archival paper"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic on wood" }
+{ "category": "Photography", "medium": "Photographic print" }
+{ "category": "Print", "medium": "C-Print on Kodak Paper" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Archival pigment print with companion NFT"}
+{ "category": "Painting", "medium": "Texture mass, acrylic, oil crayon on canvas"}
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Painting", "medium": "Coloured earth and acrylic on canvas" }
+{ "category": "Photography", "medium": "Museum quality print mounted on aluminum and acrylic"}
+{ "category": "Painting", "medium": "Watercolor, Inc, Oil pastel, Colored pencils, Acrylics"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Collages on old books paper"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Graphite, acrylic, color pencil, watercolour"}
+{ "category": "Painting", "medium": "Tempera on board" }
+{ "category": "Painting", "medium": "Mixed media on canvas" }
+{ "category": "Print", "medium": "Screen print in colours on matte board." }
+{ "category": "Print", "medium": "Screenprint in colors with hand-embellishments on Mohawk paper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil ivory-colored paper."}
+{ "category": "Print", "medium": "Screen print on paper (Portfolio of four)"}
+{ "category": "Sculpture", "medium": "Accumulated material, stoneware, 14k gold charm, work light"}
+{ "category": "Painting", "medium": "Oil on Wood" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Photography", "medium": "Lumen negative" }
+{ "category": "Sculpture", "medium": "Concrete, stones in two parts" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Print", "medium": "Lithograph in colors on B.F.K. Rives paper"}
+{ "category": "Print", "medium": "Unique handpainted acrylic and silkscreen on paper"}
+{ "category": "Mixed Media", "medium": "One-channel video with sound, 8:08min, looped. 3D printed object, recycled, transparent nylon. Video screen embedded in black acrylic case. On/off switch, sound knob."}
+{ "category": "Mixed Media", "medium": "Mixed media on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Carbonilla sobre papel"}
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Sculpture", "medium": "Rose in graduated glass cylinder, with inscription"}
+{ "category": "Installation", "medium": "Six projection screens, inflatable object, seven digital projections largely based on hand-painted slides from the 1966/67 performance (now in the collection of the Kunsthalle Bremen – Der Kunstverein in Bremen), soundtrack"}
+{ "category": "Sculpture", "medium": "White terracotta sculpture with chamotte"}
+{ "category": "Print", "medium": "Screenprint in colors" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Lithograph" }
+{ "category": "Painting", "medium": "Acrylic paint and mixed media on canvas"}
+{ "category": "Ephemera or Merchandise", "medium": "Painted cast vinyl" }
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Mixed Media", "medium": "Mixed media on cardboard in plexiglas"}
+{ "category": "Painting", "medium": "Oil on wood" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Collage on panel"}
+{ "category": "Sculpture", "medium": "Hammered safety glass, framed in an aluminium surround"}
+{ "category": "Painting", "medium": "Oil on linen" }
+{ "category": "Painting", "medium": "Flattened Corrugated Iron" }
+{ "category": "Sculpture", "medium": "Plaster, papier mâché, found wood, self-made soil-glue-mixture made of soil from the place of creation"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Screenprints on coventry rag paper" }
+{ "category": "Print", "medium": "Lithograph on Arches paper (with Arches watermark)"}
+{ "category": "Photography", "medium": "Silver gelatin print" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media on paper (acrylic and oil pastel) on drawn Fabriano paper 300 gr"}
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Painting", "medium": "Watercolor" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Oil, Acrylic on canvas" }
+{ "category": "Painting", "medium": "Double-sided, Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic paint on canvas" }
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Painting", "medium": "Acrylic On Canvas" }
+{ "category": "Painting", "medium": "Mixed Media on Paper" }
+{ "category": "Painting", "medium": "Oil & Acrylic on Canvas" }
+{ "category": "Painting", "medium": "Acrylic ink on paper" }
+{ "category": "Sculpture", "medium": "Acrylic on ceramic" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Ink on paper" }
+{ "category": "Painting", "medium": "Acrylic paint on canvas" }
+{ "category": "Sculpture", "medium": "Bronze" }
+{ "category": "Mixed Media", "medium": "Composite d'art encadré, acrylique, feuille d'argent, résine et pigment / Framed Fine Art Composite, Acrylic, Silverleaf, Resin, and Pigment"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil on Calcium Carbonate" }
+{ "category": "Textile Arts", "medium": "Instalación de 4 piezas. Bordado sobre tela con hilos de algodón de colores."}
+{ "category": "Painting", "medium": "Mixed Media" }
+{ "category": "Mixed Media", "medium": "Assemblage of plastic waste and  other materials"}
+{ "category": "Sculpture", "medium": "Stainless steel, Paint" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil and found object on wood panel" }
+{ "category": "Painting", "medium": "Oil & Wax on Board" }
+{ "category": "Painting", "medium": "Watercolor on paper" }
+{ "category": "Painting", "medium": "Pigmented plaster, pencil on panel" }
+{ "category": "Print", "medium": "22 hand printed lithographs, one photograph, and a silkscreened aluminum cover"}
+{ "category": "Painting", "medium": "Mixed technique on Canvas" }
+{ "category": "Print", "medium": "Archival pigment print in colors on wove paper"}
+{ "category": "Print", "medium": "Cibachrome print mounted to Sintra" }
+{ "category": "Painting", "medium": "Household gloss and credit card on canvas"}
+{ "category": "Print", "medium": "Woodcut with hand-coloring" }
+{ "category": "Painting", "medium": "Acrylic and oil on canvas" }
+{ "category": "Painting", "medium": "Oil on Linen" }
+{ "category": "Painting", "medium": "Oil on board" }
+{ "category": "Painting", "medium": "Acrylic and oil stick on canvas" }
+{ "category": "Sculpture", "medium": "Corten steel" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Watercolor and graphite on paper"}
+{ "category": "Print", "medium": "Silkscreen on Archival Paper" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Watercolour and pencil on paper"}
+{ "category": "Sculpture", "medium": "Bronze" }
+{ "category": "Mixed Media", "medium": "Acrylic, texture pasta on canvas" }
+{ "category": "Sculpture", "medium": "Hand carved marble stone" }
+{ "category": "Painting", "medium": "Oil on wood" }
+{ "category": "Painting", "medium": "Solid charcoal, sand, and mixed media on copper panel"}
+{ "category": "Painting", "medium": "Oil on canvas." }
+{ "category": "Print", "medium": "Woodcut" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Installation", "medium": "Crochet, Knotting Work Hemp Twine and Bio Resin Cotton Twine Polyester Cord"}
+{ "category": "Print", "medium": "Serigrafia" }
+{ "category": "Sculpture", "medium": "Lost wax bronze" }
+{ "category": "Photography", "medium": "Platinum Print on Arche Paper." }
+{ "category": "Print", "medium": "Lithograph in colors with engraving (five with collage) on Arches"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Acrylic and spray paint on wove paper"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Mixed Media", "medium": "Faux gold leaf and oil on canvas" }
+{ "category": "Painting", "medium": "Mixed media on canvas" }
+{ "category": "Painting", "medium": "Oil on panel" }
+{ "category": "Sculpture", "medium": "Bronze with accelerated verdigris patinaUnique from a Series"}
+{ "category": "Painting", "medium": "Plastic Merchandise Bags and Oil on Wooden Panel"}
+{ "category": "Painting", "medium": "Wooden frame, thermoformed Plexiglas, LED panel, metal grid, mirrored side panels, steel tubular support"}
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Sculpture", "medium": "Acrylic Spray Paint & Gilding Wax on Skateboard"}
+{ "category": "Painting", "medium": "Mixed media with silkscreen inks on paper, Signed verso"}
+{ "category": "Sculpture", "medium": "Ceramics" }
+{ "category": "Sculpture", "medium": "Bonded" }
+{ "category": "Painting", "medium": "Oil, Acrylic on canvas" }
+{ "category": "Painting", "medium": "Oil on Board" }
+{ "category": "Sculpture", "medium": "Painted Cast Vinyl" }
+{ "category": "Print", "medium": "4 Colors Offset print + Silver" }
+{ "category": "Painting", "medium": "Acrylic and Oil on Canvas" }
+{ "category": "Print", "medium": "Silkscreen" }
+{ "category": "Sculpture", "medium": "Drawing on ceramic enamel on tile at 960º C"}
+{ "category": "Photography", "medium": "Photo" }
+{ "category": "Painting", "medium": "Technique mixte sur dibond" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Lithograph"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Paper collage"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Mixed Media", "medium": "Wool on wood" }
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Oil on canvas pad" }
+{ "category": "Painting", "medium": "Mixed Media on Paper" }
+{ "category": "Print", "medium": "Lithograph on Arches paper" }
+{ "category": "Painting", "medium": "Gloss paint on board" }
+{ "category": "Photography", "medium": "Archival pigment print" }
+{ "category": "Painting", "medium": "Acrylic paint" }
+{ "category": "Sculpture", "medium": "Bamboo laminate, Irish Spring soap, toy guns, found materials"}
+{ "category": "Print", "medium": "Screenprinti n colors on wove paper" }
+{ "category": "Painting", "medium": "Acrylic and oil stick on canvas" }
+{ "category": "Sculpture", "medium": "Collage of cut up repainted and upcycled printed old master reproductions on canvas, acrylic paint and marker. Recycled acrylic sandwich frame, metal bolts and screws."}
+{ "category": "Mixed Media", "medium": "Digital pigment print and acrylic paint on canvas"}
+{ "category": "Mixed Media", "medium": "One-channel video with sound, 8:08min, looped. 3D printed object based on recycled, transparent nylon. Video screen embedded in black acrylic case. On/off switch, sound knob."}
+{ "category": "Photography", "medium": "Archival pigment print on cotton paper."}
+{ "category": "Print", "medium": "Monotype on Plike paper" }
+{ "category": "Print", "medium": "Photogravure and aquatint in colors with digital sewing collage on Magnani Pescia"}
+{ "category": "Sculpture", "medium": "Polychrome terracotta" }
+{ "category": "Painting", "medium": "Pencil, acrylic on canvas" }
+{ "category": "Painting", "medium": "Mixed media on hand stitched canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Gouache on paper"}
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Print", "medium": "Lithograph, screenprint, woodcut, and metalized PVC collage with embossing on mold-made Somerset paper"}
+{ "category": "Print", "medium": "Screenprint on Lenox Museum Board" }
+{ "category": "Textile Arts", "medium": "Pigment printing and tufted wool" }
+{ "category": "Photography", "medium": "Pigment print on Hahnemϋhle photo rag paper"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Print", "medium": "Screenprint on paper" }
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Painting", "medium": "Acrylic on canvas in artist's gold mirrored PVC frame"}
+{ "category": "Sculpture", "medium": "Murano Glass Casting" }
+{ "category": "Books and Portfolios", "medium": "Multiple, illustrated book containing 9 etchings + text"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media Crayon and pencil Drawing on paper"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Other", "medium": "Acrylic and gouache on canvas and wood" }
+{ "category": "Sculpture", "medium": "Murano Glass Casting" }
+{ "category": "Painting", "medium": "Mixed Media on canvas" }
+{ "category": "Painting", "medium": "Oil con canvas" }
+{ "category": "Mixed Media", "medium": "Collage and painting on board" }
+{ "category": "Painting", "medium": "Acrylic paint and mixed media on canvas"}
+{ "category": "Painting", "medium": "MIXED MEDIA ON CANVAS" }
+{ "category": "Painting", "medium": "Oil on jute" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Gouache and ink on paper"}
+{ "category": "Photography", "medium": "Photograph" }
+{ "category": "Print", "medium": "Screenprint with Embossing on Arches Paper"}
+{ "category": "Print", "medium": "Photogravure on Hahnemuhle with Gampi Chine Colle"}
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Etching, aquatint, spit-bite and sugarlift in colors on Arches"}
+{ "category": "Sculpture", "medium": "Glazed stoneware mask" }
+{ "category": "Mixed Media", "medium": "Mixed media on wood" }
+{ "category": "Print", "medium": "Etching" }
+{ "category": "Painting", "medium": "Mixed Media Painting" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Mixed Media", "medium": "Mixed media on canvas" }
+{ "category": "Painting", "medium": "Acrylic paint, English newspaper collage, Glitter"}
+{ "category": "Print", "medium": "C-Print on Kodak Paper" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Sculpture", "medium": "Oxidised black Palissandro marble and gold leaf"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Ink on mulberry paper"}
+{ "category": "Painting", "medium": "Acrylic on shaped canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Watercolor on paper"}
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Print", "medium": "Lithograph on heavy rag paper" }
+{ "category": "Print", "medium": "Color linocut on Arches paper" }
+{ "category": "Print", "medium": "Etching/Engraving on Paper" }
+{ "category": "Painting", "medium": "Acrylic, oilstick and charcoal on canvas"}
+{ "category": "Sculpture", "medium": "Mixed Media (wood, wood carving, wood burning, enamel)"}
+{ "category": "Mixed Media", "medium": "Digital print on textured watercolor paper"}
+{ "category": "Painting", "medium": "Mixed Media Painting" }
+{ "category": "Photography", "medium": "Digital C-Print on Archival Photographic Paper"}
+{ "category": "Print", "medium": "Color Lithograph on Arches wove paper" }
+{ "category": "Painting", "medium": "Spray paint and acrylic pen on newspaper"}
+{ "category": "Print", "medium": "Archival pigment print in colors on Archival Cotton paper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Watercolor & graphite powder"}
+{ "category": "Print", "medium": "Color lithograph on paper" }
+{ "category": "Posters", "medium": "Offset lithograph in colors on wove paper"}
+{ "category": "Painting", "medium": "OIL ON CANVAS" }
+{ "category": "Photography", "medium": "Silver gelatin print. Vintage" }
+{ "category": "Print", "medium": "Screen print on Arches Paper" }
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Oil on linen" }
+{ "category": "Sculpture", "medium": "Bronze" }
+{ "category": "Print", "medium": "Etching and aquatint on paper" }
+{ "category": "Print", "medium": "Screenprint in colors on wove paper" }
+{ "category": "Photography", "medium": "Light on emulsified Arches paper 3 hour exposure"}
+{ "category": "Print", "medium": "Etching and aquatint in colors on Japan laid to wove"}
+{ "category": "Mixed Media", "medium": "Mixed media on canvas" }
+{ "category": "Mixed Media", "medium": "OIL ON CANVAS" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Lithograph in colors on Okawara and BFK Rives"}
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Sculpture", "medium": "Polychrome Stone of Arvel" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Painting", "medium": "Spray Paint on Canvas" }
+{ "category": "Mixed Media", "medium": "Oil, acrylic, resin, shattered glass, stones, ink and glue"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil on paper"}
+{ "category": "Mixed Media", "medium": "Mixed medium on heavy card stock" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Print", "medium": "Digital print on poster paper, embossed and signed"}
+{ "category": "Painting", "medium": "Oil on canvas on cardboard" }
+{ "category": "Painting", "medium": "Paint and thread on canvas" }
+{ "category": "Painting", "medium": "Oil and acrylic on linen" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Photogravure and lithograph in colors on wove paper"}
+{ "category": "Photography", "medium": "Archival Pigment Print" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Sculpture", "medium": "Neon e Perspex" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Spray paint and stencil on wove paper"}
+{ "category": "Painting", "medium": "Acrylic and oil on canvas" }
+{ "category": "Painting", "medium": "Spray paint on canvas" }
+{ "category": "Print", "medium": "Embossed lithograph and line-cut in colors on Waterleaf handmade"}
+{ "category": "Painting", "medium": "Acrylic on Birch Panel" }
+{ "category": "Photography", "medium": "Photo" }
+{ "category": "Print", "medium": "Etching and aquatint in colors on Japon" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media on paper"}
+{ "category": "Sculpture", "medium": "Painted cast vinyl, fabric, and metal"}
+{ "category": "Print", "medium": "Pigment print on Fine Art paper" }
+{ "category": "Painting", "medium": "Mixed Media & Oils on Canvas" }
+{ "category": "Painting", "medium": "Acrylic & Pigment Colour on Paper" }
+{ "category": "Mixed Media", "medium": "Mixed media and collage of photographs on paper, 14 elements"}
+{ "category": "Photography", "medium": "Dye Sublimation on Metal Aluminum Floating Mount"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Multi-plate Silkscreen, Hand Finished by the Artist"}
+{ "category": "Print", "medium": "Silkscreen w / embossing" }
+{ "category": "Painting", "medium": "Oil on wood" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Photography", "medium": "Silver Gelatin Contact Print" }
+{ "category": "Textile Arts", "medium": "Leather, nylon, jute, wood" }
+{ "category": "Print", "medium": "Archival pigment" }
+{ "category": "Painting", "medium": "Mixed media. Reverse painting on Plexiglas."}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media on paper"}
+{ "category": "Print", "medium": "Digital pigment print on Somerset" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Sculpture", "medium": "Bronze" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Oil paintstick on printed paper"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Sculpture", "medium": "Glazed stoneware mask" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Sculpture", "medium": "Glass" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Impasto Acrylic" }
+{ "category": "Painting", "medium": "Acrylic on Board" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Linen backing on wooden frame – cotton fabric – acrylic paint – flocking powder"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Sculpture", "medium": "Bronze" }
+{ "category": "Print", "medium": "Archival pigment" }
+{ "category": "Print", "medium": "Lithograph on Rives BFK" }
+{ "category": "Mixed Media", "medium": "Mixed Media on Canvas" }
+{ "category": "Sculpture", "medium": "Oil on wood, rubber and matches" }
+{ "category": "Print", "medium": "Lithograph" }
+{ "category": "Print", "medium": "Acrylic spray paint ink on wood panel" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil on linen canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Framed collage"}
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Photography", "medium": "Digital print on Epson photo luster paper"}
+{ "category": "Mixed Media", "medium": "Digital print on textured watercolor paper, artist applied gold leaf details"}
+{ "category": "Print", "medium": "Digital prints on Lana wove paper" }
+{ "category": "Photography", "medium": "C-Print archival" }
+{ "category": "Print", "medium": "Monoprint" }
+{ "category": "Painting", "medium": "Oil on linen" }
+{ "category": "Mixed Media", "medium": "Mixed media on canvas" }
+{ "category": "Painting", "medium": "Wood relief carving and colored pencil with artist-made frame"}
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Sculpture", "medium": "Porcelain, Porcelain - buff clay blend"}
+{ "category": "Print", "medium": "Multiple, lithograph, grano-lithograph, collotype, photo-chrome from three plates. Printed in 20 colours. One element hand-collaged and two passages drawn with crayon by the artist"}
+{ "category": "Mixed Media", "medium": "Resin based on marble powder, aluminiums plates"}
+{ "category": "Print", "medium": "Silkscreen" }
+{ "category": "Print", "medium": "Serigrafia" }
+{ "category": "Painting", "medium": "Mixed media on canvas" }
+{ "category": "Mixed Media", "medium": "Pencil, marker and tape on drawing paper in acrylic frames."}
+{ "category": "Sculpture", "medium": "Sfera ConchigliaBronze" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil and acrylic on linen" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Sculpture", "medium": "Vintage book parts" }
+{ "category": "Print", "medium": "Giclée print on poly-cotton artist canvas mounted on a birch plywood stretched"}
+{ "category": "Print", "medium": "Hand finished screen print on wall clock" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Sculpture", "medium": "Glazed stoneware mask" }
+{ "category": "Photography", "medium": "Museum quality Cibachrome prints mounted between aluminum and acrylic"}
+{ "category": "Mixed Media", "medium": "Wooden marquetry with oak and birch"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic + industrial varnish on canvas"}
+{ "category": "Mixed Media", "medium": "Embroidery on fabric" }
+{ "category": "Painting", "medium": "Acrylic, Stencil, Mixed Media Painting on Paper"}
+{ "category": "Painting", "medium": "Oil on wood" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media on paper"}
+{ "category": "Sculpture", "medium": "Bronce" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil, Acrylic, Enamels on Canvas" }
+{ "category": "Sculpture", "medium": "Aluminum, acrylic spraypaint, various metallic parts"}
+{ "category": "Ephemera or Merchandise", "medium": "Painted cast vinyl" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Acrylic drawing on paper"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Photography", "medium": "Archival Pigment Print" }
+{ "category": "Painting", "medium": "Oil and encaustic on linen" }
+{ "category": "Print", "medium": "C-Print on Kodak Paper" }
+{ "category": "Photography", "medium": "Print on Canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil on ivory-colored paper"}
+{ "category": "Print", "medium": "Lithograph in colors on Arches" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media on paper"}
+{ "category": "Mixed Media", "medium": "Acrylic, wood and plexiglas" }
+{ "category": "Painting", "medium": "Oil, acrylic and oil stick on canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Print", "medium": "Serigraph" }
+{ "category": "Painting", "medium": "Oil and acrylic on canvas" }
+{ "category": "Photography", "medium": "Dye Sublimation on Metal Aluminum Floating Mount"}
+{ "category": "Sculpture", "medium": "Acrylic Spray Paint & Gilding Wax on Skateboard"}
+{ "category": "Painting", "medium": "Acrylic on Board" }
+{ "category": "Reproduction", "medium": "Color lithograph on paper" }
+{ "category": "Print", "medium": "Lithograph" }
+{ "category": "Painting", "medium": "Automotive paint on wood" }
+{ "category": "Print", "medium": "Screenprint in colors on cement" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Colored pencil on paper"}
+{ "category": "Painting", "medium": "Spraypaint on canva" }
+{ "category": "Print", "medium": "Silk screen print on paper" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Mixed Media", "medium": "Acrylic and vinyl on poly-cotton" }
+{ "category": "Other", "medium": "Ceramic" }
+{ "category": "Photography", "medium": "Chromogenic print on canvas" }
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Print", "medium": "Archival pigment ink on Innova Etching collon Rag paper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Watercolor, embossing and collage on paper"}
+{ "category": "Print", "medium": "Giclee print on Hahnemuhle Photo Rag" }
+{ "category": "Painting", "medium": "Mixed Media on Woven Fabriano" }
+{ "category": "Photography", "medium": "Archival Photographic Print" }
+{ "category": "Painting", "medium": "Acrylic on maple" }
+{ "category": "Mixed Media", "medium": "Polymaterial on board" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Photography", "medium": "Dye Sublimation on Metal Aluminum Floating Mount"}
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Watercolor"}
+{ "category": "Sculpture", "medium": "Brass& lacquer" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Ink and pencil on paper"}
+{ "category": "Textile Arts", "medium": "Screen printed cotton satin" }
+{ "category": "Print", "medium": "Twenty colour screen print on paper" }
+{ "category": "Installation", "medium": "Paintstick on anodized aluminum" }
+{ "category": "Painting", "medium": "Mixed media on canvas" }
+{ "category": "Photography", "medium": "Toned silver gelatin print" }
+{ "category": "Painting", "medium": "Oil on panel" }
+{ "category": "Painting", "medium": "Tempera on paper applied on board" }
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Painting", "medium": "Acrylic paint" }
+{ "category": "Painting", "medium": "Acrylic paint" }
+{ "category": "Print", "medium": "Laminated Giclée print on aluminium composite panel"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Printing" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media on paper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Charcoal and acrylic on burlap"}
+{ "category": "Sculpture", "medium": "Bronze" }
+{ "category": "Sculpture", "medium": "Gold leaf on wood" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Embossed woodcut print on paper, hand finished with oil paint"}
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Sculpture", "medium": "Ceramic, gold lustre" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Photography", "medium": "Chromogenic Print" }
+{ "category": "Reproduction", "medium": "Color lithograph on paper" }
+{ "category": "Print", "medium": "Screenprint on Lenox Museum Board/Arches Cover Black Paper"}
+{ "category": "Sculpture", "medium": "Photographic transfer and dermatographic pencil on canvas"}
+{ "category": "Painting", "medium": "Acrylic, oil, and pastel on linen" }
+{ "category": "Print", "medium": "Screenprint in colors on Coventry Rag paper"}
+{ "category": "Reproduction", "medium": "Color lithograph on Arjomari wove paper"}
+{ "category": "Painting", "medium": "Mixed, acrylic and spray on canvas, framed in neón orange acrylic"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Gouache on cardboard" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Painting", "medium": "Charcoal and acrylic on burlap" }
+{ "category": "Painting", "medium": "Mixed media on wood" }
+{ "category": "Mixed Media", "medium": "Knotted-stitch rugs, pure virgin wool on canvas"}
+{ "category": "Painting", "medium": "Gouache paint on canvas panel with gold leaf, varnished with wax medium. Framed in a wooden frame with gold leaf."}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Graphite on paper"}
+{ "category": "Print", "medium": "Screenprint" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Collage, VOGUE magazine on paper (200 gsm)"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil and oil sticks on canvas" }
+{ "category": "Print", "medium": "Color lithograph on Arches paper (with watermark)"}
+{ "category": "Photography", "medium": "Chromogenic Print" }
+{ "category": "Textile Arts", "medium": "Glazed stoneware vessel" }
+{ "category": "Print", "medium": "Screenprint in colors" }
+{ "category": "Print", "medium": "Digital archival print on Moab Entrada 290 gsm paper"}
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Photography", "medium": "Framed Lenticular" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Unique handpainted acrylic and silkscreen on paper"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Mixed Media", "medium": "Multi-channel video composition with sound, 8:08 minutes,  looped. Antique glass dome, white acrylic pedestal, video projections,  crystals."}
+{ "category": "Print", "medium": "Color lithograph on wove paper." }
+{ "category": "Painting", "medium": "Watercolor on paper" }
+{ "category": "Sculpture", "medium": "American Linden" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Print", "medium": "Lithograph, on light wove paper, with full margins."}
+{ "category": "Mixed Media", "medium": "나무판에 한지, 양모, 겔미디엄" }
+{ "category": "Photography", "medium": "Archival pigment print on cotton paper."}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Torndrawing, paper"}
+{ "category": "Painting", "medium": "Oil on wood" }
+{ "category": "Mixed Media", "medium": "Acrylic and emulsion on cardboard" }
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Mixed Media", "medium": "Polymaterial on cardboard applied on panel"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Sculpture", "medium": "Stoneware, found material, work light"}
+{ "category": "Textile Arts", "medium": "Mixed textile" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil on paper"}
+{ "category": "Print", "medium": "Etching" }
+{ "category": "Print", "medium": "Woodcut in violet-brown on rice paper" }
+{ "category": "Painting", "medium": "Ink and mineral colors on silk, mounted on canvas, 5 panels"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic paint" }
+{ "category": "Print", "medium": "Monotype" }
+{ "category": "Mixed Media", "medium": "Multi-channel video composition with sound, 8:08min, looped.  Hand-blown glass sculpture, video screen embedded in white acrylic case. On/off switch, sound knob."}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Ink on rice paper"}
+{ "category": "Sculpture", "medium": "Plasticine, polyester, polyuteran, plaster, ceramic tiles"}
+{ "category": "Print", "medium": "Offset Lithograph" }
+{ "category": "Sculpture", "medium": "Water, glass vessels, magnets, plastic, electronic devices, controllers"}
+{ "category": "Print", "medium": "Museum quality fine art paper (matte finish)"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Fluorescent spray paint on handmade paper"}
+{ "category": "Painting", "medium": "Acrylic and Oil on Canvas" }
+{ "category": "Painting", "medium": "Graphite, marker, varnish, acrylic on canvas"}
+{ "category": "Painting", "medium": "Acrylic paint" }
+{ "category": "Installation", "medium": "Wood, copper wires, controllers, PC"}
+{ "category": "Ephemera or Merchandise", "medium": "Painted cast resin" }
+{ "category": "Print", "medium": "Lithograph in colors on wove paper" }
+{ "category": "Sculpture", "medium": "Anti-reflective laminated glass" }
+{ "category": "Painting", "medium": "Linen paper, acrylic paint, textural paste on natural canvas"}
+{ "category": "Mixed Media", "medium": "Collage made with photographs of my authorship and digitally manipulated"}
+{ "category": "Painting", "medium": "Pigment and silica on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media"}
+{ "category": "Sculpture", "medium": "Porcelain, Porcelain - buff clay blend"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic paint and mixed media on two canvas"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media on paper"}
+{ "category": "Print", "medium": "Lithograph on paper" }
+{ "category": "Print", "medium": "Limited edition print, edition of 20" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Sculpture", "medium": "Resin, Pigment, Acrylic" }
+{ "category": "Painting", "medium": "Watercolor on wood cat head panel" }
+{ "category": "Print", "medium": "Lambda print in colors on Fujicolour digital archival"}
+{ "category": "Mixed Media", "medium": "Ink, collage & acrylic on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Gouache"}
+{ "category": "Print", "medium": "Lithograph with Chine applique on Arches and Japanese Yame handmade"}
+{ "category": "Design/Decorative Art", "medium": "Stoneware and reactive glazes"}
+{ "category": "Print", "medium": "Etching" }
+{ "category": "Painting", "medium": "Oil on wood" }
+{ "category": "Print", "medium": "Impresión sobre aluminio dibond / Photographic Print on Aluminum Dibond"}
+{ "category": "Photography", "medium": "Silver gelatin print" }
+{ "category": "Textile Arts", "medium": "Textil artesanal, hilos lana y fibra de magueyHandmade textile, wool yarns and maguey fiber"}
+{ "category": "Sculpture", "medium": "Acrylic on wood" }
+{ "category": "Photography", "medium": "Triptych, mounted color photographs"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Sculpture", "medium": "Bonded stone" }
+{ "category": "Painting", "medium": "Acrylics on canvas" }
+{ "category": "Print", "medium": "Lithograph" }
+{ "category": "Print", "medium": "Offset lithograph and screenprint in colors on Arches Cover"}
+{ "category": "Print", "medium": "Photogravure on Gampi, with vintage wallpaper, wax, mounted on cotton rag paper"}
+{ "category": "Sculpture", "medium": "Neon e Perspex" }
+{ "category": "Painting", "medium": "Technique mixte sur toile" }
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Mixed Media", "medium": "Mixed technique on paper" }
+{ "category": "Print", "medium": "Multiple, silkscreen on paper" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Watercolor and pencil on paper"}
+{ "category": "Painting", "medium": "Acrylic paint" }
+{ "category": "Painting", "medium": "Ink on paper" }
+{ "category": "Print", "medium": "Multiple, silkscreen on blackboard, wooden frame"}
+{ "category": "Painting", "medium": "Mineral pigment, Dyed mud pigment, Pencil, Colored pencil"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Torndrawing, paper"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Mixed Media", "medium": "Acrylic with embroidery on raw canvas"}
+{ "category": "Print", "medium": "Etching and aquatint on velin d'Arches" }
+{ "category": "Painting", "medium": "Japanese paper, Mineral pigment, Whitewash"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Screenprint in colors on Mohawk paper" }
+{ "category": "Sculpture", "medium": "Steel on paper, glass and wood" }
+{ "category": "Print", "medium": "Etching and sugar-lift aquatint in colors on Somerset Textured"}
+{ "category": "Painting", "medium": "Acrylic on cotton canvas" }
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Sculpture", "medium": "Resin" }
+{ "category": "Print", "medium": "Offset lithograph on lightweight off-white paper"}
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil on linen" }
+{ "category": "Sculpture", "medium": "Stainless steel, mahogany" }
+{ "category": "Painting", "medium": "Plastic Merchandise Bags and Oil on Wooden Panel"}
+{ "category": "Sculpture", "medium": "Glass" }
+{ "category": "Painting", "medium": "Acrylic and Leaf Foil on Canvas" }
+{ "category": "Textile Arts", "medium": "Hand woven cotton" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Watercolor, acrylic and gouache on paper"}
+{ "category": "Textile Arts", "medium": "Wool tapestry" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic paint, Paper, Mixed media" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Acrílico sobre papel"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Mixed Media", "medium": "Wool on wood" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pastel and mixed media on paper"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Alu-Dibond, Digigraphie and Methacrylate" }
+{ "category": "Print", "medium": "Serigraph" }
+{ "category": "Print", "medium": "Offset Lithograph" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic and Pigments on Canvas" }
+{ "category": "Print", "medium": "Silkscreen on Premium Paper with Deckled Edges"}
+{ "category": "Mixed Media", "medium": "Oil and acrylic on canvas" }
+{ "category": "Print", "medium": "A unique original digital painting printed on aluminium."}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Archival pigment printing" }
+{ "category": "Mixed Media", "medium": "Aluminum on board" }
+{ "category": "Print", "medium": "Lithograph on heavy rag paper" }
+{ "category": "Print", "medium": "Lithograph in colors on Arches" }
+{ "category": "Sculpture", "medium": "Bronze" }
+{ "category": "Painting", "medium": "Acrylic and automotive paint on aluminium"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Mixed Media", "medium": "Mixed media on paper" }
+{ "category": "Print", "medium": "Lithograph on BFK Rives" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Colored pencil on Bristol vellum paper"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Print", "medium": "Etching and Aquatint" }
+{ "category": "Sculpture", "medium": "Mixed media" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Indian ink on paper"}
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Sculpture", "medium": "Limewood & Acrylic" }
+{ "category": "Painting", "medium": "Wood relief carving and oil with artist-made frame"}
+{ "category": "Sculpture", "medium": "Kiln Formed Glass" }
+{ "category": "Sculpture", "medium": "Bronze, Iron Base" }
+{ "category": "Print", "medium": "Serigraph" }
+{ "category": "Print", "medium": "Etching" }
+{ "category": "Print", "medium": "Etching and Aquatint" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Acrylic on paper"}
+{ "category": "Painting", "medium": "Oil and acrylic on wood and styrofoam" }
+{ "category": "Sculpture", "medium": "Acrylic paint, stone clay, Japanese paper, rhinestones"}
+{ "category": "Photography", "medium": "Silver Gelatin Print" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed media on paper applied on canvas"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Colored pencil on Bristol vellum paper"}
+{ "category": "Painting", "medium": "Paint on sicofoil" }
+{ "category": "Design/Decorative Art", "medium": "Porcelain" }
+{ "category": "Print", "medium": "6 Colour Screenprint on Saunders Waterfoot 425 gr"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Mixed on paper"}
+{ "category": "Painting", "medium": "Painted glazed biscuit tiles" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Mixed Media", "medium": "Wood, metal, electric motor" }
+{ "category": "Mixed Media", "medium": "Mixed media on paper" }
+{ "category": "Painting", "medium": "Mixed Media On Canvas" }
+{ "category": "Painting", "medium": "Ink on paper" }
+{ "category": "Painting", "medium": "Acrylic on panel" }
+{ "category": "Painting", "medium": "Acrylic and pastel on canvas" }
+{ "category": "Painting", "medium": "Enamel on emulsified canvas" }
+{ "category": "Print", "medium": "Aquagravure" }
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Painting", "medium": "Oil on linen" }
+{ "category": "Sculpture", "medium": "Acrylic on resin" }
+{ "category": "Print", "medium": "Screenprint in colors on wove paper" }
+{ "category": "Other", "medium": "Glazed Ceramic" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas, wood frame" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Colored pencil on paper"}
+{ "category": "Photography", "medium": "Plexiglass, Photography" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Watercolor and graphite on paper"}
+{ "category": "Mixed Media", "medium": "Photographic printing on fabric, embroidery, pearls and sequins"}
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Mixed Media", "medium": "Embroidery on fabric" }
+{ "category": "Painting", "medium": "Oil on wood" }
+{ "category": "Painting", "medium": "Tempera on linen" }
+{ "category": "Painting", "medium": "Mixed technic on illustration board" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Acrylic and oil on paper"}
+{ "category": "Painting", "medium": "Mixed media on wood" }
+{ "category": "Painting", "medium": "Encaustic and mixed media" }
+{ "category": "Mixed Media", "medium": "Small cylinders painted on 4 assembled boards"}
+{ "category": "Painting", "medium": "Mixed media on canvas" }
+{ "category": "Print", "medium": "Lithograph in colors on wove paper" }
+{ "category": "Photography", "medium": "Dye sublimated on aluminum" }
+{ "category": "Painting", "medium": "Oil, Watercolor, Sumi Ink, Bee Wax on Panel"}
+{ "category": "Photography", "medium": "Silver gelatin print" }
+{ "category": "Painting", "medium": "Acrylic on wood" }
+{ "category": "Reproduction", "medium": "Color lithograph on Arjomari wove paper"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Sculpture", "medium": "Mixed media" }
+{ "category": "Sculpture", "medium": "Water, glass vessels, magnets, plastic, electronic devices, controllers"}
+{ "category": "Print", "medium": "Screenprint, Relief, Etching, Lithograph, Engraving, and Stencil on white TGL Handmade paper"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Mixed Media on Canvas" }
+{ "category": "Sculpture", "medium": "Mixed media, ACP, plexiglass" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Tempera on paper applied on panel"}
+{ "category": "Painting", "medium": "Technique mixte sur dibond" }
+{ "category": "Painting", "medium": "Oil on Board" }
+{ "category": "Painting", "medium": "Oil and acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Sculpture", "medium": "Stoneware" }
+{ "category": "Textile Arts", "medium": "Peeled willow twigs, paper morbaebark"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil on black paper"}
+{ "category": "Posters", "medium": "Offset lithograph in colors on wove paper"}
+{ "category": "Print", "medium": "Archival pigment ink print on 315 gsm paper"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Sculpture", "medium": "Bronze" }
+{ "category": "Print", "medium": "C-Print on Kodak Paper" }
+{ "category": "Sculpture", "medium": "Wood, plaster, and paint" }
+{ "category": "Sculpture", "medium": "Water, glass vessels, magnets, plastic, electronic devices, controllers"}
+{ "category": "Mixed Media", "medium": "Mixed media and collage on Schoeller cardboard"}
+{ "category": "Print", "medium": "Digital impression on pumice stone" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Sculpture", "medium": "Cherry" }
+{ "category": "Print", "medium": "Photolithograph in colors on French Dur-O-Tone"}
+{ "category": "Print", "medium": "Aquatint and lift-ground etching on J.B. Green"}
+{ "category": "Mixed Media", "medium": "Engraving on painted wood" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Lithograph" }
+{ "category": "Painting", "medium": "Mixed media on canvas" }
+{ "category": "Painting", "medium": "Oil on cardboard" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Print", "medium": "Etching and aquatint in colors" }
+{ "category": "Reproduction", "medium": "Color lithograph on Arjomari wove paper"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Mixed Media", "medium": "Fur, leather, frame" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Giclée in colors on Somerset Velvet paper"}
+{ "category": "Reproduction", "medium": "Offset print on Arches paper" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Screenprint in colours, on wove paper, with full margins"}
+{ "category": "Painting", "medium": "Oil colors and beaten metal on linen" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Mixed media on canvas." }
+{ "category": "Painting", "medium": "Double-sided, Oil on canvas" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Print", "medium": "C-Print on Kodak Paper" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Mixed media on canvas" }
+{ "category": "Sculpture", "medium": "Ceramic covered with automotive paint"}
+{ "category": "Painting", "medium": "Oil on Panel" }
+{ "category": "Reproduction", "medium": "Color lithograph on Arjomari wove paper"}
+{ "category": "Painting", "medium": "Collage, Acrylic & Sculpture on Canva" }
+{ "category": "Painting", "medium": "Cartapesta,foglia d'oro, acrilico su tela"}
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Print", "medium": "Etching" }
+{ "category": "Painting", "medium": "Grease pencil, marker, chalk, acrylic, varnish on canvas"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Mixed Media", "medium": "Ditone printing on paper, beveled glass and marquetry"}
+{ "category": "Painting", "medium": "Mixed media (dyed and sewn textiles, acrylic)"}
+{ "category": "Painting", "medium": "Acrylic on Watercolor Paper" }
+{ "category": "Painting", "medium": "Plaster, polymer, pigment, scrim, oil" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Oil on linen" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Painting", "medium": "Watercolor and graphite on paper" }
+{ "category": "Print", "medium": "Color lithograph" }
+{ "category": "Photography", "medium": "Inkjet print" }
+{ "category": "Painting", "medium": "Acrylic paint, English newspaper collage"}
+{ "category": "Print", "medium": "Lenticulair with frame" }
+{ "category": "Painting", "medium": "Mixed medium on poster print" }
+{ "category": "Painting", "medium": "Mixed media on panel" }
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Painting", "medium": "Acrylic and collage on canvas" }
+{ "category": "Painting", "medium": "Oil on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pigment and acrylic on paper"}
+{ "category": "Print", "medium": "Lithograph in colors on Arches" }
+{ "category": "Painting", "medium": "Collage, Korean rice paper (Hanji) and oil on canvas"}
+{ "category": "Sculpture", "medium": "Slip cast porcelain and glass rods" }
+{ "category": "Painting", "medium": "Acrylic on canvas cardboard" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Pencil on paper"}
+{ "category": "Sculpture", "medium": "Porcelain, Plastecine" }
+{ "category": "Photography", "medium": "Digital C-Print on Archival Photographic Paper"}
+{ "category": "Painting", "medium": "Acrylic & Pigment Colour on Paper" }
+{ "category": "Mixed Media", "medium": "Acrylic on birch plywood, metal hinges"}
+{ "category": "Print", "medium": "Lithograph" }
+{ "category": "Print", "medium": "Serigrafia" }
+{ "category": "Sculpture", "medium": "Polished graphite and oxide powder on aluminum"}
+{ "category": "Photography", "medium": "Archival Pigment Print" }
+{ "category": "Print", "medium": "Silkscreen on Somerset Satin paper" }
+{ "category": "Painting", "medium": "Collage on Canvas" }
+{ "category": "Painting", "medium": "Oil painting" }
+{ "category": "Painting", "medium": "Acrylic on Board" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Collage on panel"}
+{ "category": "Painting", "medium": "Acrylic and oil pastel on canvas" }
+{ "category": "Print", "medium": "Ink on paper" }
+{ "category": "Print", "medium": "Multiple, embossing on paper" }
+{ "category": "Painting", "medium": "Acrylic, charcoal on Cotton canvas" }
+{ "category": "Painting", "medium": "Oil on Linen" }
+{ "category": "Sculpture", "medium": "Pigment and glaze on stoneware and gold"}
+{ "category": "Mixed Media", "medium": "Paper" }
+{ "category": "Painting", "medium": "Oil, Watercolor, Sumi Ink, Bee Wax on Panel"}
+{ "category": "Sculpture", "medium": "Solid Bronze, Marble" }
+{ "category": "Photography", "medium": "Archival Pigment Print" }
+{ "category": "Painting", "medium": "Acrylic on shaped canvas" }
+{ "category": "Painting", "medium": "Acrylic , mixed media on canvas" }
+{ "category": "Photography", "medium": "Archival Pigment Print" }
+{ "category": "Print", "medium": "Screenprint in colors over collage" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Sumi-ink on paper"}
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Print", "medium": "Lithograph" }
+{ "category": "Painting", "medium": "Plaster, polymer, pigment, scrim, oil" }
+{ "category": "Painting", "medium": "Handcrafted oil on linen" }
+{ "category": "Print", "medium": "12 Colour Screenprint with a Varnish Overlay on Somerset Satin Tub Sized 410gsm Paper"}
+{ "category": "Print", "medium": "Giclee in colors on Cotton paper" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Sculpture", "medium": "Original statue / edited with more than 75,000 swarovski crystals"}
+{ "category": "Print", "medium": "Lithograph" }
+{ "category": "Photography", "medium": "Silver gelatin print" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Ink on paper"}
+{ "category": "Painting", "medium": "Acrylic paint, Aluminum foil" }
+{ "category": "Painting", "medium": "Acrylic paint, Paper, Mixed media" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Painstick on printed paper"}
+{ "category": "Painting", "medium": "Linocut, silk, cotton, ceramic, encaustic painting on wood"}
+{ "category": "Sculpture", "medium": "Bronze" }
+{ "category": "Other", "medium": "Charred Oak" }
+{ "category": "Painting", "medium": "Acrylic on Canvas" }
+{ "category": "Print", "medium": "Giclée in colors on Archival Fine Art paper"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Giclée, screenprint acrylic and oil and hand applied varnish on paper"}
+{ "category": "Painting", "medium": "Oil, acrylic, spray paint, sand, bees wax on canvas"}
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Painting", "medium": "Oil and silverpoint on paper mounted on wooden structure"}
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Photography", "medium": "Archival Pigment Print" }
+{ "category": "Painting", "medium": "Acrylic on canvas" }
+{ "category": "Painting", "medium": "Glass mosaics" }
+{ "category": "Print", "medium": "Lithograph in colors" }
+{ "category": "Photography", "medium": "Archival Pigment Print" }
+{ "category": "Sculpture", "medium": "Acrylic on wood" }
+{ "category": "Photography", "medium": "Silver Gelatin Contact Print" }
+{ "category": "Photography", "medium": "Silver Gelatin Print" }
+{ "category": "Print", "medium": "C-Print" }
+{ "category": "Painting", "medium": "Mixed Media, Acrylic on canvas" }
+{ "category": "Sculpture", "medium": "Wool felt" }
+{ "category": "Print", "medium": "4 Colour Screenprint with Hand Painted Background on Plywood"}
+{ "category": "Mixed Media", "medium": "Mixed Media Silkscreened Prints  on Deckled Paper"}
+{ "category": "Painting", "medium": "Oil on Canvas" }
+{ "category": "Other", "medium": "Sycamore" }
+{ "category": "Painting", "medium": "Oil on wood" }
+{ "category": "Painting", "medium": "Acrylic and automotive paint on aluminium panel"}
+{ "category": "Painting", "medium": "Mixed media" }
+{ "category": "Painting", "medium": "Oil on paper, mounted on wood" }
+{ "category": "Print", "medium": "Screenprint in colours on paper" }
+{ "category": "Painting", "medium": "Acrylic paint, Oil painting" }
+{ "category": "Print", "medium": "Ink on paper" }
+{ "category": "Print", "medium": "28 Color Screen Print" }
+{ "category": "Print", "medium": "Screenprint in colors on Special Arjomari"}
+{ "category": "Painting", "medium": "Oil on board" }
+{ "category": "Painting", "medium": "Spray paint and acrylic pen on newspaper"}
+{ "category": "Mixed Media", "medium": "Mixed media on cardboard" }
+{ "category": "Sculpture", "medium": "Resin, tar, steel, acrylic, LED" }
+{ "category": "Photography", "medium": "Stampa cromogenica da negativo 4.5x6 cm"}
+{ "category": "Drawing, Collage or other Work on Paper", "medium": "Acrylic on paper"}
+{ "category": "Painting", "medium": "Oil on linen" }
+{ "category": "Sculpture", "medium": "Resin/Epoxy" }

--- a/src/12-fine-tuning/lib/data.ts
+++ b/src/12-fine-tuning/lib/data.ts
@@ -1,0 +1,87 @@
+import fs from "fs"
+import path from "path"
+import dedent from "dedent"
+import { SELECTED_INPUT } from "12-fine-tuning/01-medium"
+
+const SYSTEM_PROMPT =
+  "Your task is to identify the medium (aka 'medium type') of an artwork based on a description of the materials within it. If you cannot infer the medium type then answer with the string <unknown>."
+
+/**
+ * Takes raw data from Gravity of the form…
+ *
+ * ```json
+ * { "category": "Painting", "medium": "Oil on Wood" }
+ * { "category": "Sculpture", "medium": "Stoneware" }
+ * ```
+ * …and turns it into properly formatted training and validation data for the model.
+ *
+ * The raw data files are expected in the `data/raw` directory, in JSONL format.
+ */
+export async function prepareData() {
+  const dataPath = path.resolve(
+    __dirname,
+    "..",
+    "data",
+    "raw",
+    `${SELECTED_INPUT}.jsonl`
+  )
+  const data = fs.readFileSync(dataPath, "utf-8")
+
+  const trainingSetPath = path.resolve(
+    __dirname,
+    "..",
+    "data",
+    "training",
+    "medium-training-data.jsonl"
+  )
+  const trainingSet = fs.createWriteStream(trainingSetPath)
+
+  const validationSetPath = path.resolve(
+    __dirname,
+    "..",
+    "data",
+    "training",
+    "medium-validation-data.jsonl"
+  )
+  const validationSet = fs.createWriteStream(validationSetPath)
+
+  const documents = data.split("\n")
+  const trainingSetSize = Math.round(0.8 * documents.length)
+  const validationSetSize = documents.length - trainingSetSize
+
+  const trainingDocuments = documents.slice(0, trainingSetSize)
+  const validationDocuments = documents.slice(trainingSetSize, documents.length)
+
+  console.log(`\nWriting ${trainingSetSize} training data…`)
+  trainingDocuments.forEach(async (doc) => {
+    process.stdout.write(".")
+    trainingSet.write(formatExample(doc) + "\n")
+  })
+  trainingSet.end()
+  console.log("\nDone.")
+
+  console.log(`\nWriting ${validationSetSize} validation data…`)
+  validationDocuments.forEach(async (doc) => {
+    process.stdout.write(".")
+    validationSet.write(formatExample(doc) + "\n")
+  })
+  validationSet.end()
+
+  // artificial delay
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+
+  console.log("\nDone.")
+}
+
+/**
+ * Takes a category/medium pair and formats it as a training example.
+ *
+ * @param inputDocument Object of the form `{ "category": "Painting", "medium": "Oil on Wood" }`
+ * @returns a message list consisting of a system prompt, user input, and ideal assistant response.
+ */
+function formatExample(inputDocument: string) {
+  const { category, medium } = JSON.parse(inputDocument)
+  return dedent`
+  { "messages": [ { "role": "system", "content": "${SYSTEM_PROMPT}" }, { "role": "user", "content": "${medium}" }, { "role": "assistant", "content": "${category}" }]}
+  `
+}

--- a/src/12-fine-tuning/lib/file.ts
+++ b/src/12-fine-tuning/lib/file.ts
@@ -1,0 +1,48 @@
+import fs from "fs"
+import path from "path"
+import OpenAI from "openai"
+import dotenv from "dotenv"
+
+dotenv.config()
+
+/**
+ * Assuming that the training & validation datasets have been built from the raw data,
+ * this method uploads the training & validation datasets to OpenAI.
+ *
+ * @returns Object containing OpenAI responses for the training and validation data
+ */
+export async function uploadData() {
+  const trainingSetPath = path.resolve(
+    __dirname,
+    "..",
+    "data",
+    "training",
+    "medium-training-data.jsonl"
+  )
+  const validationSetPath = path.resolve(
+    __dirname,
+    "..",
+    "data",
+    "training",
+    "medium-validation-data.jsonl"
+  )
+
+  const trainingData = await uploadFile(trainingSetPath)
+  const validationData = await uploadFile(validationSetPath)
+  console.log({ trainingData, validationData })
+  return { trainingData, validationData }
+}
+
+/**
+ * Uploads a single file to the OpenAI's file storage.
+ *
+ * @param path Path to the file that is going to be uploaded
+ * @returns an `OpenAI.Files.FileObject` corresponding to the uploaded file
+ */
+async function uploadFile(path: string) {
+  const openai = new OpenAI()
+  return await openai.files.create({
+    file: fs.createReadStream(path),
+    purpose: "fine-tune",
+  })
+}

--- a/src/12-fine-tuning/lib/fine-tune.ts
+++ b/src/12-fine-tuning/lib/fine-tune.ts
@@ -1,0 +1,56 @@
+import { SELECTED_INPUT } from "12-fine-tuning/01-medium"
+import OpenAI from "openai"
+import dotenv from "dotenv"
+
+dotenv.config()
+
+/**
+ * Kicks off a fine-tuning job with the uploaded training and validation datasets.
+ * Continues polling for status until the job is complete.
+ *
+ * @param uploads An object with the references to the uploaded training and validation datasets.
+ * @returns A `OpenAI.FineTuning.Jobs.FineTuningJob` with the final state of the fine-tuning job, whether `succeeded`, `failed`, or `cancelled`.
+ */
+export async function submitFineTuneJob(uploads: {
+  trainingData: OpenAI.Files.FileObject
+  validationData: OpenAI.Files.FileObject
+}) {
+  const {
+    trainingData: { id: training_file },
+    validationData: { id: validation_file },
+  } = uploads
+
+  const openai = new OpenAI()
+  const fineTune = await openai.fineTuning.jobs.create({
+    training_file,
+    validation_file,
+    model: "gpt-3.5-turbo",
+    suffix: SELECTED_INPUT,
+  })
+  console.log({ fineTune })
+
+  let fineTuneState = await openai.fineTuning.jobs.retrieve(fineTune.id)
+
+  const notDone = (status: typeof fineTuneState.status) => {
+    return (
+      status !== "succeeded" && status !== "failed" && status !== "cancelled"
+    )
+  }
+
+  while (notDone(fineTuneState.status)) {
+    fineTuneState = await openai.fineTuning.jobs.retrieve(fineTune.id)
+    // @ts-expect-error `estimated_finish` is not in the type definition
+    const { id, created_at, status, estimated_finish } = fineTuneState
+
+    console.log({
+      id,
+      created_at: new Date(created_at * 1000),
+      status,
+      estimated_finish: new Date(estimated_finish * 1000),
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+  }
+
+  return fineTuneState
+}

--- a/src/12-fine-tuning/lib/test.ts
+++ b/src/12-fine-tuning/lib/test.ts
@@ -1,0 +1,71 @@
+import OpenAI from "openai"
+
+// spell-checker:disable
+const testCases = {
+  "Oil on canvas": "Painting",
+  "Stainless steel, painted wood": "Sculpture",
+  "Screenprint in colors on Cream Speckletone paper": "Print",
+  "Pigment transfer on polylaminate": "Photography",
+  "Oil on board, gold frame": "Painting",
+  "Canvas, Acrylic, pen, paper, pencil": "Painting",
+  "BASF Luran": "Print",
+  "Archival pigment print with polymer on Washi paper": "Mixed Media",
+}
+// spell-checker:enable
+
+export async function assessFineTune({ modelId }: { modelId: string }) {
+  const results: AssessmentResult[] = []
+
+  for (const [medium, category] of Object.entries(testCases)) {
+    const result = await assessFineTuneCase({ modelId, medium, category })
+    results.push(result)
+  }
+
+  return results
+}
+
+export type AssessmentResult = {
+  medium: string
+  category: string
+  predictedCategory: string
+  isCorrect: boolean
+}
+
+async function assessFineTuneCase({
+  modelId,
+  medium,
+  category,
+}: {
+  modelId: string
+  medium: string
+  category: string
+}): Promise<AssessmentResult> {
+  const openai = new OpenAI()
+  const response = await openai.chat.completions.create({
+    model: modelId,
+    messages: [
+      {
+        role: "system",
+        content:
+          "Identify the medium type based on the provided description of materials",
+      },
+      { role: "user", content: medium },
+    ],
+  })
+  const predictedCategory = response.choices[0].message.content!
+  const isCorrect = predictedCategory === category
+  console.log({ medium, category, predictedCategory, isCorrect })
+  return { medium, category, predictedCategory, isCorrect }
+}
+
+/**
+ * Logs out how many of the results were correct.
+ *
+ * @param results The results of the assessment.
+ */
+export function summarizeResults(results: AssessmentResult[]) {
+  const correct = results.filter((result) => result.isCorrect).length
+  const total = results.length
+  const accuracy = (correct / total) * 100
+  console.log(`\nAccuracy: ${accuracy.toFixed(2)}%`)
+}


### PR DESCRIPTION
Re: https://www.notion.so/artsy/Explore-fine-tuning-a-model-to-achieve-better-tone-voice-799995bf6791465c84f3bdc6161a35bc?pvs=4

We paired earlier on the question of how to get started with fine-tuning a model for voice and tone. 

There were various blockers, so we instead pivoted to creating a simple fine-tuned model that could be applied to a different problem in our domain. A realistic but [solved](https://github.com/artsy/spectroscopy/pull/109) one: **identifying the medium of an artwork based on its materials description**.

Here I flesh out that experiment and add a new script:

```sh
yarn tsx src/12-fine-tuning/01-medium.ts
```

Running that^ will:

- create training and validation data sets 
- upload them to OpenAI's file storage
- use OpenAI's fine-tuning API to create a customized model
- test the new fine-tuned model by sending it a few novel examples

Essentially the approach consists of providing a bunch of examples in the form of a conversational message list, in which the `assistant` message represents the ideal response which needs to be learned by the model. More or less like:

```json
[
  {
    "messages": [
      { "role": "user", "content": "Oil on canvas" },
      { "role": "assistant", "content": "Painting" }
    ]
  },
  {
    "messages": [
      { "role": "user", "content": "Bronze and wood" },
      { "role": "assistant", "content": "Sculpture" }
    ]
  },
  {
    "messages": [
      { "role": "user", "content": "Gelatin silver print" },
      { "role": "assistant", "content": "Photography" }
    ]
  }
]
```

After the fine-tuning is complete, the script runs a tiny test on some unseen examples to assess accuracy, e.g.:

```js
[...]
{
  medium: 'Oil on board, gold frame',
  category: 'Painting',
  predictedCategory: 'Painting',
  isCorrect: true
}
{
  medium: 'Archival pigment print with polymer on Washi paper',
  category: 'Mixed Media',
  predictedCategory: 'Photography',
  isCorrect: false
}
[...]

Accuracy: 75.00%
```