### PR TITLE
feat: adopt chunking for Positron RAG articles

### DIFF
--- a/src/06-positron-rag/02-insert-articles.ts
+++ b/src/06-positron-rag/02-insert-articles.ts
@@ -2,12 +2,12 @@ import { listArticles } from "./lib/insert/listArticles"
 import { prepareArticlesCollection } from "./lib/insert/prepareArticlesCollection"
 import { insertArticles } from "./lib/insert/insertArticles"
 
-export const CLASS_NAME: string = "ArticleV1"
+export const CLASS_NAME: string = "ArticleSections"
 
 async function main() {
   const articles = listArticles()
   await prepareArticlesCollection()
-  insertArticles(articles)
+  await insertArticles(articles)
 }
 
 main()

--- a/src/06-positron-rag/lib/extract/transformArticle.ts
+++ b/src/06-positron-rag/lib/extract/transformArticle.ts
@@ -81,7 +81,7 @@ function getArticleMetadata(article: any) {
     description,
     keywords,
     vertical,
-    channelName: channel.name,
+    channelName: channel?.name,
   }
 }
 

--- a/src/06-positron-rag/lib/extract/transformArticle.ts
+++ b/src/06-positron-rag/lib/extract/transformArticle.ts
@@ -9,6 +9,8 @@ export type TransformedArticle = {
     href: string
     publishedAt: string
     byline: string
+    description: string
+    keywords: string[]
     vertical: string
     channelName: string
   }
@@ -64,6 +66,7 @@ function getArticleMetadata(article: any) {
     href,
     publishedAt,
     byline,
+    description,
     keywords,
     vertical,
     channel,
@@ -75,6 +78,7 @@ function getArticleMetadata(article: any) {
     href,
     publishedAt,
     byline,
+    description,
     keywords,
     vertical,
     channelName: channel.name,

--- a/src/06-positron-rag/lib/insert/prepareArticlesCollection.ts
+++ b/src/06-positron-rag/lib/insert/prepareArticlesCollection.ts
@@ -79,16 +79,16 @@ export async function prepareArticlesCollection() {
           },
         },
       },
-      // {
-      //   name: "keyword",
-      //   dataType: ["text"],
-      //   moduleConfig: {
-      //     "text2vec-openai": {
-      //       skip: true,
-      //       // vectorizePropertyName: false,
-      //     },
-      //   },
-      // },
+      {
+        name: "keywords",
+        dataType: ["text[]"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+            // vectorizePropertyName: false,
+          },
+        },
+      },
       {
         name: "vertical",
         dataType: ["text"],
@@ -110,7 +110,17 @@ export async function prepareArticlesCollection() {
         },
       },
       {
-        name: "head",
+        name: "sectionIndex",
+        dataType: ["int"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+            // vectorizePropertyName: false,
+          },
+        },
+      },
+      {
+        name: "section",
         dataType: ["text"],
         moduleConfig: {
           "text2vec-openai": {
@@ -120,7 +130,7 @@ export async function prepareArticlesCollection() {
         },
       },
       {
-        name: "body",
+        name: "articleDescription",
         dataType: ["text"],
         moduleConfig: {
           "text2vec-openai": {


### PR DESCRIPTION
Continuation of the Positron RAG FF work (builds on #12)

The typical first step in a RAG pipeline is to take each document to be ingested, and slice it into _chunks_ of a few hundred tokens each.

Then, vectorization is performed on the chunks rather than on the entire document, in order to promote better relevance during the retrieval stage. In theory we only retrieve the most relevant portion(s) of a document rather then the entire document which may or may not be relevant.

The data modeling in Positron helps us out here, it turns out, because every article is _already_ chunked into a series of "sections."

![article chunks](https://github.com/artsy/quantum/assets/140521/9690dbd0-4062-4ae4-8e13-da81880cc1a5)

These typically work out to be a couple of hundred tokens, so we leverage this natural chunking in this PR.

This means that we've gone from vectorizing 100 article _summaries_, to ~600 article _sections_, in the hopes that we can hone in one more relevant _retrieved_ results in order to better _generate_ a response.

Preliminary results shared [here](https://artsy.slack.com/archives/C06SSV1K10D/p1717427824697189?thread_ts=1715982890.406339&cid=C06SSV1K10D).
