### PR TITLE
Mc jones anandaroop/ingest artworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ src/11-brushy-cli/**/*.txt
 # fine-tuning mediums
 src/12-fine-tuning/data/training/*
 !src/12-fine-tuning/data/training/.gitkeep
+src/14-curated-discovery/data/**/*.json

--- a/src/14-curated-discovery/01-artworks.ts
+++ b/src/14-curated-discovery/01-artworks.ts
@@ -1,10 +1,9 @@
-import path from "path"
-import fs from "fs"
 import weaviate, { generateUuid5 } from "weaviate-ts-client"
 import _ from "lodash"
 import { GravityArtwork } from "./types"
 import { deleteIfExists } from "system/weaviate"
 import dotenv from "dotenv"
+import { getArtworks } from "./helpers"
 
 dotenv.config()
 
@@ -230,21 +229,6 @@ async function prepareArtworkCollection() {
     .do()
 
   console.log(JSON.stringify(classResult, null, 2))
-}
-
-/**
- * Read artworks from a local JSON file
- *
- * The JSON file will be gitignored, but the data can
- * be obtained from a shared folder, currently at:
- *
- * https://drive.google.com/drive/u/1/folders/1Lh7msUc0R_JlpNEzApZ4YbqB8x5tbpws
- */
-async function getArtworks() {
-  const filePath = path.join(__dirname, "./data/artworks.json")
-  const data = await fs.promises.readFile(filePath, "utf-8")
-  const artworks: GravityArtwork[] = JSON.parse(data)
-  return artworks
 }
 
 /**

--- a/src/14-curated-discovery/01-artworks.ts
+++ b/src/14-curated-discovery/01-artworks.ts
@@ -1,0 +1,302 @@
+import path from "path"
+import fs from "fs"
+import weaviate, { generateUuid5 } from "weaviate-ts-client"
+import _ from "lodash"
+import { GravityArtwork } from "./types"
+import { deleteIfExists } from "system/weaviate"
+import dotenv from "dotenv"
+
+dotenv.config()
+
+const CLASS_NAME = "DiscoveryArtworks"
+const BATCH_SIZE = 100
+
+const client = weaviate.client({
+  host: process.env.WEAVIATE_URL!,
+})
+
+async function main() {
+  await deleteIfExists(CLASS_NAME)
+  await prepareArtworkCollection()
+  const artworks = await getArtworks()
+  await insertArtworks(artworks)
+}
+
+/**
+ * Create and configure a new collection to hold artworks
+ */
+async function prepareArtworkCollection() {
+  const classWithProps = {
+    class: CLASS_NAME,
+    vectorizer: "text2vec-openai",
+    moduleConfig: {
+      "text2vec-openai": {
+        model: "text-embedding-3-small",
+        dimensions: 1536,
+        type: "text",
+        vectorizeClassName: false,
+      },
+    },
+    properties: [
+      {
+        name: "internalID",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+      {
+        name: "slug",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+      {
+        name: "title",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+            vectorizePropertyName: true,
+          },
+        },
+      },
+      {
+        name: "date",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+            vectorizePropertyName: true,
+          },
+        },
+      },
+      {
+        name: "rarity",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+            vectorizePropertyName: true,
+          },
+        },
+      },
+      {
+        name: "medium",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+            vectorizePropertyName: true,
+          },
+        },
+      },
+      {
+        name: "materials",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+            vectorizePropertyName: true,
+          },
+        },
+      },
+      {
+        name: "dimensions",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+            vectorizePropertyName: true,
+          },
+        },
+      },
+      {
+        name: "price",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+            vectorizePropertyName: true,
+          },
+        },
+      },
+      {
+        name: "listPriceAmount",
+        dataType: ["number"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+      {
+        name: "listPriceCurrency",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+      {
+        name: "artworkLocation",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+            vectorizePropertyName: true,
+          },
+        },
+      },
+      {
+        name: "categories",
+        dataType: ["text[]"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+            vectorizePropertyName: true,
+          },
+        },
+      },
+      {
+        name: "tags",
+        dataType: ["text[]"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+            vectorizePropertyName: true,
+          },
+        },
+      },
+      {
+        name: "additionalInformation",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+            vectorizePropertyName: true,
+          },
+        },
+      },
+      {
+        name: "imageUrl",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+      {
+        name: "imageDescription",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+            vectorizePropertyName: true,
+          },
+        },
+      },
+      {
+        name: "artistID",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+      {
+        name: "partnerID",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+    ],
+  }
+
+  const classResult = await client.schema
+    .classCreator()
+    .withClass(classWithProps)
+    .do()
+
+  console.log(JSON.stringify(classResult, null, 2))
+}
+
+/**
+ * Read artworks from a local JSON file
+ *
+ * The JSON file will be gitignored, but the data can
+ * be obtained from a shared folder, currently at:
+ *
+ * https://drive.google.com/drive/u/1/folders/1Lh7msUc0R_JlpNEzApZ4YbqB8x5tbpws
+ */
+async function getArtworks() {
+  const filePath = path.join(__dirname, "./data/artworks.json")
+  const data = await fs.promises.readFile(filePath, "utf-8")
+  const artworks: GravityArtwork[] = JSON.parse(data)
+  return artworks
+}
+
+/**
+ * Insert artworks into Weaviate
+ *
+ * Also assigns a deterministic UUID to each artwork,
+ * based on its Gravity ID
+ */
+async function insertArtworks(
+  artworks: GravityArtwork[],
+  batchSize: number = BATCH_SIZE
+) {
+  console.log(`Inserting artwork: ${artworks.length}`)
+
+  const batches = _.chunk(artworks, batchSize)
+  console.log(`Inserting ${batches.length} batches`)
+
+  for (const artworkBatch of batches) {
+    let batcher = client.batch.objectsBatcher()
+    batcher = batcher.withObjects(
+      ...artworkBatch.map((artwork) => {
+        return {
+          class: CLASS_NAME,
+          properties: {
+            internalID: artwork.id,
+            slug: artwork.slug,
+            title: artwork.title,
+            date: artwork.date,
+            rarity: artwork.rarity,
+            medium: artwork.medium,
+            materials: artwork.materials,
+            dimensions: artwork.dimensions,
+            price: artwork.price,
+            listPriceAmount: artwork.list_price_amount,
+            listPriceCurrency: artwork.list_price_currency,
+            artworkLocation: artwork.artwork_location,
+            categories: artwork.categories,
+            tags: artwork.tags,
+            additionalInformation: artwork.additional_information,
+            imageUrl: artwork.image_url,
+            imageDescription: null, // TODO: add computer vision step?
+            artistID: artwork.artist_id,
+            partnerID: artwork.partner_id,
+          },
+          id: generateUuid5(artwork.id),
+        }
+      })
+    )
+    process.stdout.write(".")
+    await batcher.do()
+  }
+  process.stdout.write("\n")
+}
+
+main().catch(console.error)

--- a/src/14-curated-discovery/02-user.ts
+++ b/src/14-curated-discovery/02-user.ts
@@ -1,0 +1,125 @@
+import { deleteIfExists } from "system/weaviate"
+import weaviate, { generateUuid5 } from "weaviate-ts-client"
+import _ from "lodash"
+// import { getArtworks } from "./01-ingest-artworks"
+import { ClassName, GravityArtwork, ReferenceProperty, User } from "./types"
+import dotenv from "dotenv"
+import fs from "fs"
+import path from "path"
+
+dotenv.config()
+
+// Constants
+const CLASS_NAME: ClassName = "DiscoveryUsers"
+const USER: User = { id: "abc123", name: "Test" }
+const BATCH_SIZE: number = 10
+const SAMPLE_SIZE: number = 5
+
+const client = weaviate.client({
+  host: process.env.WEAVIATE_URL!,
+})
+
+async function main() {
+  // const artworks = await getArtworks()
+  const filePath = path.join(__dirname, "./data/artworks.json")
+  const data = await fs.promises.readFile(filePath, "utf-8")
+  const artworks: GravityArtwork[] = JSON.parse(data)
+  const sampleArtworkIds = _.shuffle(artworks.map((el) => el.id)).slice(
+    0,
+    SAMPLE_SIZE
+  )
+
+  await prepareCollection("DiscoveryUsers")
+  await insertObjects([USER], BATCH_SIZE)
+  await createReferences(
+    USER,
+    sampleArtworkIds,
+    "DiscoveryArtworks",
+    "likedArtworks"
+  )
+}
+
+async function prepareCollection(className: ClassName) {
+  await deleteIfExists(className)
+
+  const classSchema = {
+    class: className,
+    moduleConfig: {
+      "ref2vec-centroid": {
+        referenceProperties: ["likedArtworks"],
+      },
+    },
+    vectorizer: "ref2vec-centroid",
+    properties: [
+      {
+        name: "name",
+        dataType: ["string"],
+        description: "Name of the user",
+      },
+      {
+        name: "likedArtworks",
+        dataType: ["DiscoveryArtworks"],
+        description: "Artworks liked by the user",
+      },
+    ],
+  }
+
+  const classResult = await client.schema
+    .classCreator()
+    .withClass(classSchema)
+    .do()
+
+  console.log(JSON.stringify(classResult, null, 2))
+}
+
+async function insertObjects(objects: User[], batchSize: number) {
+  console.log(`Inserting users: ${objects.length}`)
+
+  const batches = _.chunk(objects, batchSize)
+  console.log(`Inserting ${batches.length} batches`)
+
+  for (const userBatch of batches) {
+    let batcher = client.batch.objectsBatcher()
+    batcher = batcher.withObjects(
+      ...userBatch.map((user) => {
+        return {
+          class: "DiscoveryUsers",
+          properties: _.omit(user, ["id"]),
+          id: generateUuid5(user.id),
+        }
+      })
+    )
+    process.stdout.write(`${userBatch.length}`)
+    await batcher.do()
+  }
+  process.stdout.write("\n")
+}
+
+async function createReferences(
+  object: User,
+  referenceIDs: string[],
+  referenceClassName: ClassName,
+  referenceProperty: ReferenceProperty
+) {
+  const objectId = object.id
+
+  for (const referenceId of referenceIDs) {
+    console.log(`Creating references for ${objectId} to ${referenceId}: `)
+
+    await client.data
+      .referenceCreator()
+      .withClassName(CLASS_NAME)
+      .withId(generateUuid5(objectId))
+      .withReferenceProperty(referenceProperty)
+      .withReference(
+        client.data
+          .referencePayloadBuilder()
+          .withClassName(referenceClassName)
+          .withId(generateUuid5(referenceId))
+          .payload()
+      )
+      .do()
+  }
+}
+
+main()

--- a/src/14-curated-discovery/helpers.ts
+++ b/src/14-curated-discovery/helpers.ts
@@ -1,0 +1,18 @@
+import { GravityArtwork } from "./types"
+import path from "path"
+import fs from "fs"
+
+/**
+ * Read artworks from a local JSON file
+ *
+ * The JSON file will be gitignored, but the data can
+ * be obtained from a shared folder, currently at:
+ *
+ * https://drive.google.com/drive/u/1/folders/1Lh7msUc0R_JlpNEzApZ4YbqB8x5tbpws
+ */
+export async function getArtworks() {
+  const filePath = path.join(__dirname, "./data/artworks.json")
+  const data = await fs.promises.readFile(filePath, "utf-8")
+  const artworks: GravityArtwork[] = JSON.parse(data)
+  return artworks
+}

--- a/src/14-curated-discovery/types.ts
+++ b/src/14-curated-discovery/types.ts
@@ -1,0 +1,27 @@
+export type GravityArtwork = {
+  id: string
+  slug: string
+  title: string
+  date: string
+  rarity: string
+  medium: string
+  materials: string
+  dimensions: string
+  price: string
+  list_price_amount: number
+  list_price_currency: string
+  artwork_location: string
+  categories: string[]
+  tags: string[]
+  additional_information: string
+  image_url: string
+  artist_id: string
+  artist_slug: string
+  artist_name: string
+  artist_nationality: string
+  artist_birthday: string
+  artist_gender: string
+  partner_id: string
+  partner_slug: string
+  partner_name: string
+}

--- a/src/14-curated-discovery/types.ts
+++ b/src/14-curated-discovery/types.ts
@@ -25,3 +25,9 @@ export type GravityArtwork = {
   partner_slug: string
   partner_name: string
 }
+
+export type User = { id: string; name: string }
+
+export type ClassName = "DiscoveryArtworks" | "DiscoveryUsers"
+
+export type ReferenceProperty = "likedArtworks"


### PR DESCRIPTION
As we turn our focus to the [curated discovery experiment](https://www.notion.so/artsy/AI-Innovation-Squad-Q2-2024-619cf183deb449e39cea411777af5071?p=5e43238042014fae853222582a35acd9&pm=s) we start by seeding a more extensive dataset than in our previous experiments.

This PR adds ingestion scripts for artworks and users.

```sh
yarn tsx src/14-curated-discovery/01-artworks.ts
yarn tsx src/14-curated-discovery/02-user.ts
```

The artworks data comes from a static data dump that currently resides in [a shared folder](https://drive.google.com/drive/u/1/folders/1Lh7msUc0R_JlpNEzApZ4YbqB8x5tbpws) and consists of a small and a medium dataset:

- several hundred artworks belonging to selected curated collections (the ones that appear the main dropdown nav under Artists), along with their associated artists and partners

- several thousand artworks belonging to **_all_** curated collections, along with their associated artists and partners

The goal is to prove out some approaches on these smaller datasets before scaling up to a larger one.

The user data is just a single stub user for now, but set up for use with ref2vec-centroids.


