### PR TITLE
feat: add a multimodal version of the artwork collection

### DIFF
--- a/src/14-curated-discovery/03-artworks-multimodal.ts
+++ b/src/14-curated-discovery/03-artworks-multimodal.ts
@@ -1,0 +1,129 @@
+import weaviate, { generateUuid5 } from "weaviate-ts-client"
+import _ from "lodash"
+import { GravityArtwork } from "./types"
+import { deleteIfExists } from "system/weaviate"
+import dotenv from "dotenv"
+import { getArtworks, getImageDataForArtworks } from "./helpers"
+
+dotenv.config()
+
+const CLASS_NAME = "DiscoveryArtworksMM"
+const BATCH_SIZE = 5
+
+const client = weaviate.client({
+  host: process.env.WEAVIATE_URL!,
+})
+
+async function main() {
+  await deleteIfExists(CLASS_NAME)
+  await prepareArtworkCollection()
+  const artworks = await getArtworks()
+  await insertArtworks(artworks)
+}
+
+/**
+ * Create and configure a new collection to hold artworks
+ */
+async function prepareArtworkCollection() {
+  const classWithProps = {
+    class: CLASS_NAME,
+    vectorizer: "multi2vec-clip",
+    moduleConfig: {
+      "multi2vec-clip": {
+        textFields: [
+          "title",
+          "medium",
+          "materials",
+          "categories",
+          "tags",
+          "additionalInformation",
+        ],
+        imageFields: ["image"],
+      },
+    },
+    properties: [
+      { name: "internalID", dataType: ["text"] },
+      { name: "slug", dataType: ["text"] },
+      { name: "title", dataType: ["text"] },
+      { name: "date", dataType: ["text"] },
+      { name: "rarity", dataType: ["text"] },
+      { name: "medium", dataType: ["text"] },
+      { name: "materials", dataType: ["text"] },
+      { name: "dimensions", dataType: ["text"] },
+      { name: "price", dataType: ["text"] },
+      { name: "listPriceAmount", dataType: ["number"] },
+      { name: "listPriceCurrency", dataType: ["text"] },
+      { name: "artworkLocation", dataType: ["text"] },
+      { name: "categories", dataType: ["text[]"] },
+      { name: "tags", dataType: ["text[]"] },
+      { name: "additionalInformation", dataType: ["text"] },
+      { name: "imageUrl", dataType: ["text"] },
+      { name: "image", dataType: ["blob"] },
+      { name: "artistID", dataType: ["text"] },
+      { name: "partnerID", dataType: ["text"] },
+    ],
+  }
+
+  const classResult = await client.schema
+    .classCreator()
+    .withClass(classWithProps)
+    .do()
+
+  console.log(JSON.stringify(classResult, null, 2))
+}
+/**
+ * Insert artworks into Weaviate
+ *
+ * Also assigns a deterministic UUID to each artwork,
+ * based on its Gravity ID
+ */
+async function insertArtworks(
+  artworks: GravityArtwork[],
+  batchSize: number = BATCH_SIZE
+) {
+  console.log(`Inserting artwork: ${artworks.length}`)
+
+  const batches = _.chunk(artworks, batchSize)
+  console.log(`Inserting ${batches.length} batches`)
+
+  for (const artworkBatch of batches) {
+    const imageData = await getImageDataForArtworks(artworkBatch)
+
+    let batcher = client.batch.objectsBatcher()
+    batcher = batcher.withObjects(
+      ...artworkBatch.map((artwork) => {
+        return {
+          class: CLASS_NAME,
+          properties: {
+            internalID: artwork.id,
+            slug: artwork.slug,
+            title: artwork.title,
+            date: artwork.date,
+            rarity: artwork.rarity,
+            medium: artwork.medium,
+            materials: artwork.materials,
+            dimensions: artwork.dimensions,
+            price: artwork.price,
+            listPriceAmount: artwork.list_price_amount,
+            listPriceCurrency: artwork.list_price_currency,
+            artworkLocation: artwork.artwork_location,
+            categories: artwork.categories,
+            tags: artwork.tags,
+            additionalInformation: artwork.additional_information,
+            imageUrl: artwork.image_url,
+            image: imageData[artwork.id],
+            artistID: artwork.artist_id,
+            partnerID: artwork.partner_id,
+          },
+          id: generateUuid5(artwork.id),
+        }
+      })
+    )
+    process.stdout.write(".")
+    await batcher.do()
+  }
+  process.stdout.write("\n")
+  console.log("Done.")
+}
+
+main().catch(console.error)

--- a/src/14-curated-discovery/helpers.ts
+++ b/src/14-curated-discovery/helpers.ts
@@ -1,6 +1,7 @@
 import { GravityArtwork } from "./types"
 import path from "path"
 import fs from "fs"
+import _ from "lodash"
 
 /**
  * Read artworks from a local JSON file
@@ -15,4 +16,62 @@ export async function getArtworks() {
   const data = await fs.promises.readFile(filePath, "utf-8")
   const artworks: GravityArtwork[] = JSON.parse(data)
   return artworks
+}
+
+/**
+ * Read an image over the network and convert it to a base64 string
+ *
+ * @param imageUrl URL of the image to read
+ * @returns Base64 encoded image data
+ */
+export async function getBase64Blob(imageUrl: string): Promise<string> {
+  const response = await fetch(imageUrl)
+  const buffer = await response.arrayBuffer()
+  return Buffer.from(buffer).toString("base64")
+}
+
+/**
+ * Generate an url for a resized, cached version of an image.
+ *
+ * Makes use of Gemini's crop endpoint (media.artsy.net/crop) to
+ * resize the image to fit the desired width and height.
+ *
+ * The actual request is issued to the Cloudfront distribution,
+ * so that the resized image is cached and served from the CDN.
+ *
+ * @param src URL of the original image
+ * @param options.width (optional) desired width of the resized image, defaults to 512
+ * @param options.height (optional) desired height of the resized image, defaults to 512
+ * @returns
+ */
+export function resizeImage(
+  src: string,
+  options?: {
+    width: number
+    height: number
+  }
+) {
+  const { width, height } = _.defaults(options, { width: 512, height: 512 })
+  return `https://d7hftxdivxxvm.cloudfront.net/?src=${src}&resize_to=fit&width=${width}&height=${height}&grow=false`
+}
+
+/**
+ * Return a mapping of artwork ids to their respective image contents
+ * as Base64-encoded strings.
+ *
+ * @param artworkBatch - an array of artwork objects
+ * @returns a dictionary of artwork IDs and their Base64 encoded images
+ */
+export async function getImageDataForArtworks(
+  artworks: GravityArtwork[]
+): Promise<{ [key: string]: string }> {
+  const imageFieldPairs = await Promise.all(
+    artworks.map(async (artwork) => {
+      const resizedImageUrl = resizeImage(artwork.image_url)
+      const image = await getBase64Blob(resizedImageUrl)
+      return [artwork.id, image]
+    })
+  )
+  const imageData = _.fromPairs(imageFieldPairs)
+  return imageData
 }


### PR DESCRIPTION
This is one of the [previously mentioned](https://github.com/artsy/quantum/pull/22#discussion_r1628438275) follow-ups to https://github.com/artsy/quantum/pull/22

This adds another artwork collection, which makes use of the [`multi2vec-clip` model](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip) for multimodal text+image embeddings. 

The new collection is named `DiscoverArtworksMM` to distinguish it as the multimodal alternative to `DiscoveryArtworks`

```sh
yarn tsx src/14-curated-discovery/03-artworks-multimodal.ts
```

```graphql
{
  Get {
    DiscoveryArtworksMM(
      nearText: {
        concepts: ["nautical"]
      }
    ) {
      title
      imageUrl
    }
  }
}
```