### PR TITLE
feat: support reranking collections with cohere

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
   "cSpell.words": [
     "Deleter",
     "openai",
+    "rerank",
+    "reranker",
     "vectorize",
     "vectorizer",
     "weaviate"

--- a/src/14-curated-discovery/06-collections.ts
+++ b/src/14-curated-discovery/06-collections.ts
@@ -38,6 +38,9 @@ async function prepareCollectionsCollection() {
         type: "text",
         vectorizeClassName: true,
       },
+      "reranker-cohere": {
+        model: "rerank-multilingual-v3.0",
+      },
     },
     properties: [
       {


### PR DESCRIPTION
This PR adds the ability to rerank collections query results using cohere. Supports experimenting reranking collection results with the collector's 'goal'. Can still query without re-ranking as before.

### Related PR
- https://github.com/artsy/force/pull/14050
- https://github.com/artsy/substance/pull/388

---
### WITHOUT reranking
![Screenshot 2024-06-21 at 2 36 39 PM](https://github.com/artsy/quantum/assets/38149304/3e7fc253-9994-4b25-986c-47780c0d82dc)


### WITH reranking
![Screenshot 2024-06-21 at 2 34 58 PM](https://github.com/artsy/quantum/assets/38149304/c7832666-3542-4df7-829b-b492d5e8a2e6)