### PR TITLE
feat: include imageUrl with Articles objects

### DIFF
--- a/src/06-positron-rag/lib/extract/fetchArticles.ts
+++ b/src/06-positron-rag/lib/extract/fetchArticles.ts
@@ -26,6 +26,9 @@ export async function fetchArticles(
             searchTitle # unused?
             href
             publishedAt
+            thumbnailImage {
+              imageURL
+            }
 
             # creators
             byline

--- a/src/06-positron-rag/lib/extract/transformArticle.ts
+++ b/src/06-positron-rag/lib/extract/transformArticle.ts
@@ -13,6 +13,7 @@ export type TransformedArticle = {
     keywords: string[]
     vertical: string
     channelName: string
+    imageUrl: string
   }
   head: string
   body: string
@@ -70,6 +71,7 @@ function getArticleMetadata(article: any) {
     keywords,
     vertical,
     channel,
+    thumbnailImage,
   } = article
 
   return {
@@ -82,6 +84,7 @@ function getArticleMetadata(article: any) {
     keywords,
     vertical,
     channelName: channel?.name,
+    imageUrl: thumbnailImage?.imageURL,
   }
 }
 

--- a/src/06-positron-rag/lib/insert/insertArticles.ts
+++ b/src/06-positron-rag/lib/insert/insertArticles.ts
@@ -61,6 +61,7 @@ function propertiesFromArticleSection(
     keywords: article.metadata.keywords,
     vertical: article.metadata.vertical,
     channelName: article.metadata.channelName,
+    imageUrl: article.metadata.imageUrl,
     sectionIndex,
 
     // content, maybe vectorized

--- a/src/06-positron-rag/lib/insert/prepareArticlesCollection.ts
+++ b/src/06-positron-rag/lib/insert/prepareArticlesCollection.ts
@@ -137,6 +137,16 @@ export async function prepareArticlesCollection() {
           },
         },
       },
+      {
+        name: "imageUrl",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+            // vectorizePropertyName: false,
+          },
+        },
+      },
     ],
   }
 


### PR DESCRIPTION
Small PR to include a `Article`'s `imageUrl` when uploading it into `weaviate`. Seemed like it may be useful for other purposes. Can also close this if we think its too specific to the linked to PR below. 

### Related PR
- https://github.com/artsy/force/pull/14064