### PR TITLE
feat: incorporate numeric USD prices

### DIFF
--- a/src/14-curated-discovery/01-artworks.ts
+++ b/src/14-curated-discovery/01-artworks.ts
@@ -144,6 +144,24 @@ async function prepareArtworkCollection() {
         },
       },
       {
+        name: "priceMinMinorUSD",
+        dataType: ["number"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+      {
+        name: "priceMaxMinorUSD",
+        dataType: ["number"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+      {
         name: "artworkLocation",
         dataType: ["text"],
         moduleConfig: {
@@ -264,6 +282,8 @@ async function insertArtworks(
             price: artwork.price,
             listPriceAmount: artwork.list_price_amount,
             listPriceCurrency: artwork.list_price_currency,
+            priceMinMinorUSD: artwork.price_min_minor_usd,
+            priceMaxMinorUSD: artwork.price_max_minor_usd,
             artworkLocation: artwork.artwork_location,
             categories: artwork.categories,
             tags: artwork.tags,

--- a/src/14-curated-discovery/data.md
+++ b/src/14-curated-discovery/data.md
@@ -88,6 +88,8 @@ puts JSON.pretty_generate(artworks.map do |w|
     price: w.sale_message,
     list_price_amount: w.price_listed,
     list_price_currency: w.price_currency,
+    price_min_minor_usd: w.price_min_minor_usd,
+    price_max_minor_usd: w.price_max_minor_usd,
     artwork_location: w.location&.geocoded_city,
     categories: w.total_genome.without("Art", "Career Stage Gene").select{ |k,v| k !~ /(galleries based|made in)/i && v == 100}.keys,
     tags: w.tags + w.auto_tags,

--- a/src/14-curated-discovery/types.ts
+++ b/src/14-curated-discovery/types.ts
@@ -24,6 +24,8 @@ export type GravityArtwork = {
   price: string
   list_price_amount: number
   list_price_currency: string
+  price_min_minor_usd: number
+  price_max_minor_usd: number
   artwork_location: string
   categories: string[]
   tags: string[]


### PR DESCRIPTION
This addresses the lack of good, filterable price data in the current artworks collection.

We do this by reading from some [newly added price fields](https://github.com/artsy/gravity/pull/17790)  on the Artwork model (`price_min_minor_usd` and `price_max_minor_usd`). This gives us prices that:

- are numerical
- reflect a price range, if applicable
- are normalize to USD via Gravity's exchange rates (a snapshot as of today, of course, not kept up-to-date in this prototype)
