### PR TITLE
feat: add infinite discovery users and artworks schemas

### DIFF
--- a/src/17-infinite-discovery/01-user.ts
+++ b/src/17-infinite-discovery/01-user.ts
@@ -1,0 +1,87 @@
+import weaviate, { generateUuid5 } from "weaviate-ts-client"
+import _ from "lodash"
+import dotenv from "dotenv"
+import { UsersClassName, User } from "./types"
+import { deleteIfExists } from "system/weaviate"
+
+// Config
+dotenv.config()
+
+// Constants
+const CLASS_NAME: UsersClassName = "InfiniteDiscoveryUsers"
+const USERS: User[] = []
+const BATCH_SIZE: number = 10
+
+const client = weaviate.client({
+  host: process.env.WEAVIATE_URL!,
+})
+
+async function main() {
+  await prepareCollection(CLASS_NAME)
+  await insertObjects(USERS, BATCH_SIZE)
+}
+
+main()
+
+async function prepareCollection(className: UsersClassName) {
+  await deleteIfExists(className)
+
+  const classSchema = {
+    class: className,
+    moduleConfig: {
+      "ref2vec-centroid": {
+        referenceProperties: ["likedArtworks"],
+      },
+    },
+    vectorizer: "ref2vec-centroid",
+    properties: [
+      {
+        name: "internalID",
+        dataType: ["string"],
+        description: "Artsy's internal ID for the user.",
+      },
+      {
+        name: "likedArtworks",
+        dataType: ["InfiniteDiscoveryArtworks"],
+        description:
+          "Artworks liked by this user. Used to calculate the user's vector.",
+      },
+      {
+        name: "DislikedArtworks",
+        dataType: ["InfiniteDiscoveryArtworks"],
+        description:
+          "Artworks disliked by this user. Used to calculate filter the artworks from infinite discovery results.",
+      },
+    ],
+  }
+
+  const classResult = await client.schema
+    .classCreator()
+    .withClass(classSchema)
+    .do()
+
+  console.log(JSON.stringify(classResult, null, 2))
+}
+
+async function insertObjects(objects: User[], batchSize: number) {
+  console.log(`Inserting users: ${objects.length}`)
+
+  const batches = _.chunk(objects, batchSize)
+  console.log(`Inserting ${batches.length} batches`)
+
+  for (const userBatch of batches) {
+    let batcher = client.batch.objectsBatcher()
+    batcher = batcher.withObjects(
+      ...userBatch.map((user) => {
+        return {
+          class: CLASS_NAME,
+          properties: user,
+          id: generateUuid5(user.internalID),
+        }
+      })
+    )
+    process.stdout.write(`${userBatch.length}`)
+    await batcher.do()
+  }
+  process.stdout.write("\n")
+}

--- a/src/17-infinite-discovery/01-user.ts
+++ b/src/17-infinite-discovery/01-user.ts
@@ -52,7 +52,7 @@ async function prepareCollection(className: UsersClassName) {
         name: "DislikedArtworks",
         dataType: ["InfiniteDiscoveryArtworks"],
         description:
-          "Artworks disliked by this user. Used to calculate filter the artworks from infinite discovery results.",
+          "Artworks disliked by this user. Used to filter the artworks from infinite discovery results.",
       },
     ],
   }

--- a/src/17-infinite-discovery/01-user.ts
+++ b/src/17-infinite-discovery/01-user.ts
@@ -18,7 +18,9 @@ const client = weaviate.client({
 
 async function main() {
   await prepareCollection(CLASS_NAME)
-  await insertObjects(USERS, BATCH_SIZE)
+  if (USERS.length !== 0) {
+    await insertObjects(USERS, BATCH_SIZE)
+  }
 }
 
 main()

--- a/src/17-infinite-discovery/02-artworks.ts
+++ b/src/17-infinite-discovery/02-artworks.ts
@@ -1,0 +1,126 @@
+import weaviate from "weaviate-ts-client"
+import dotenv from "dotenv"
+import { deleteIfExists } from "system/weaviate"
+import { ArtworksClassName } from "./types"
+
+dotenv.config()
+
+// Constants
+const CLASS_NAME: ArtworksClassName = "InfiniteDiscoveryArtworks"
+
+const client = weaviate.client({
+  host: process.env.WEAVIATE_URL!,
+})
+
+async function main() {
+  await prepareCollection()
+}
+
+main()
+
+async function prepareCollection() {
+  await deleteIfExists(CLASS_NAME)
+
+  const classWithProps = {
+    class: CLASS_NAME,
+    vectorizer: "text2vec-openai",
+    moduleConfig: {
+      "text2vec-openai": {
+        model: "text-embedding-3-small",
+        dimensions: 1536,
+        type: "text",
+        vectorizeClassName: false,
+      },
+    },
+    properties: [
+      {
+        name: "internalID",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
+      {
+        name: "rarity",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+      {
+        name: "medium",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
+      {
+        name: "saleMessage",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
+      {
+        name: "colors",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
+      {
+        name: "slug",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+      {
+        name: "url",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+      {
+        name: "title",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
+      {
+        name: "imageUrl",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+    ],
+  }
+
+  const classResult = await client.schema
+    .classCreator()
+    .withClass(classWithProps)
+    .do()
+
+  console.log(JSON.stringify(classResult, null, 2))
+}

--- a/src/17-infinite-discovery/02-artworks.ts
+++ b/src/17-infinite-discovery/02-artworks.ts
@@ -38,7 +38,7 @@ async function prepareCollection() {
         dataType: ["text"],
         moduleConfig: {
           "text2vec-openai": {
-            skip: false,
+            skip: true,
           },
         },
       },

--- a/src/17-infinite-discovery/02-artworks.ts
+++ b/src/17-infinite-discovery/02-artworks.ts
@@ -114,6 +114,24 @@ async function prepareCollection() {
           },
         },
       },
+      {
+        name: "listPriceAmount",
+        dataType: ["number"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
+      {
+        name: "listPriceCurrency",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: true,
+          },
+        },
+      },
     ],
   }
 

--- a/src/17-infinite-discovery/types.ts
+++ b/src/17-infinite-discovery/types.ts
@@ -1,0 +1,5 @@
+export type ArtworksClassName = "InfiniteDiscoveryArtworks"
+
+export type UsersClassName = "InfiniteDiscoveryUsers"
+
+export type User = { internalID: string; name: string }


### PR DESCRIPTION
This PR adds a new directory, `17-infinite-discovery`. This would allow us to create two new classes in `weaviate`: `ArtworksInfiniteDiscovery` and `UsersInfiniteDiscovery` in prep for a POC. 

If we are a happy with this initial schema, I can begin work on importing a subset of Artworks.

[DIA-917]

[DIA-917]: https://artsyproduct.atlassian.net/browse/DIA-917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ