### PR TITLE
feat: import artworks into InfiniteDiscoverArtworks collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ src/14-curated-discovery/data/**/*.json
 
 # art-quiz json
 src/16-art-quiz/data/*
+
+# infinite-discovery json
+src/17-infinite-discovery/data/*

--- a/src/17-infinite-discovery/01-user.ts
+++ b/src/17-infinite-discovery/01-user.ts
@@ -9,7 +9,7 @@ dotenv.config()
 
 // Constants
 const CLASS_NAME: UsersClassName = "InfiniteDiscoveryUsers"
-const USERS: User[] = []
+const USERS: User[] = [{ internalID: "1", name: "Jane Tester" }]
 const BATCH_SIZE: number = 10
 
 const client = weaviate.client({
@@ -49,7 +49,7 @@ async function prepareCollection(className: UsersClassName) {
           "Artworks liked by this user. Used to calculate the user's vector.",
       },
       {
-        name: "DislikedArtworks",
+        name: "dislikedArtworks",
         dataType: ["InfiniteDiscoveryArtworks"],
         description:
           "Artworks disliked by this user. Used to filter the artworks from infinite discovery results.",

--- a/src/17-infinite-discovery/02-artworks.ts
+++ b/src/17-infinite-discovery/02-artworks.ts
@@ -1,12 +1,15 @@
-import weaviate from "weaviate-ts-client"
-import dotenv from "dotenv"
+import _ from "lodash"
+import { ArtworksClassName, GravityArtwork } from "./types"
 import { deleteIfExists } from "system/weaviate"
-import { ArtworksClassName } from "./types"
+import { getArtworks } from "./helpers"
+import dotenv from "dotenv"
+import weaviate, { generateUuid5 } from "weaviate-ts-client"
 
 dotenv.config()
 
 // Constants
 const CLASS_NAME: ArtworksClassName = "InfiniteDiscoveryArtworks"
+const BATCH_SIZE: number = 100
 
 const client = weaviate.client({
   host: process.env.WEAVIATE_URL!,
@@ -14,9 +17,9 @@ const client = weaviate.client({
 
 async function main() {
   await prepareCollection()
+  const artworks = await getArtworks()
+  await insertArtworks(artworks)
 }
-
-main()
 
 async function prepareCollection() {
   await deleteIfExists(CLASS_NAME)
@@ -61,17 +64,8 @@ async function prepareCollection() {
         },
       },
       {
-        name: "saleMessage",
-        dataType: ["text"],
-        moduleConfig: {
-          "text2vec-openai": {
-            skip: false,
-          },
-        },
-      },
-      {
         name: "colors",
-        dataType: ["text"],
+        dataType: ["text[]"],
         moduleConfig: {
           "text2vec-openai": {
             skip: false,
@@ -132,6 +126,78 @@ async function prepareCollection() {
           },
         },
       },
+      {
+        name: "date",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
+      {
+        name: "materials",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
+      {
+        name: "tags",
+        dataType: ["text[]"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
+      {
+        name: "additionalInformation",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
+      {
+        name: "artistName",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
+      {
+        name: "artistNationality",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
+      {
+        name: "artistBirthday",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
+      {
+        name: "artistGender",
+        dataType: ["text"],
+        moduleConfig: {
+          "text2vec-openai": {
+            skip: false,
+          },
+        },
+      },
     ],
   }
 
@@ -142,3 +208,57 @@ async function prepareCollection() {
 
   console.log(JSON.stringify(classResult, null, 2))
 }
+
+/**
+ * Insert artworks into Weaviate
+ *
+ * Also assigns a deterministic UUID to each artwork,
+ * based on its Gravity ID
+ */
+async function insertArtworks(
+  artworks: GravityArtwork[],
+  batchSize: number = BATCH_SIZE
+) {
+  console.log(`Inserting artwork: ${artworks.length}`)
+
+  const batches = _.chunk(artworks, batchSize)
+  console.log(`Inserting ${batches.length} batches`)
+
+  for (const artworkBatch of batches) {
+    let batcher = client.batch.objectsBatcher()
+    batcher = batcher.withObjects(
+      ...artworkBatch.map((artwork) => {
+        return {
+          class: CLASS_NAME,
+          properties: {
+            internalID: artwork.id,
+            slug: artwork.slug,
+            title: artwork.title,
+            date: artwork.date,
+            rarity: artwork.rarity,
+            medium: artwork.medium,
+            materials: artwork.materials,
+            listPriceAmount: artwork.list_price_amount,
+            listPriceCurrency: artwork.list_price_currency,
+            categories: artwork.categories,
+            tags: artwork.tags,
+            additionalInformation: artwork.additional_information,
+            imageUrl: artwork.image_url,
+            colors: artwork.colors,
+            artistName: artwork.artist_name,
+            artistNationality: artwork.artist_nationality,
+            artistBirthday: artwork.artist_birthday,
+            artistGender: artwork.artist_gender,
+          },
+          id: generateUuid5(artwork.id),
+        }
+      })
+    )
+    process.stdout.write(".")
+    await batcher.do()
+  }
+  process.stdout.write("\n")
+}
+
+// Run the script
+main()

--- a/src/17-infinite-discovery/data.md
+++ b/src/17-infinite-discovery/data.md
@@ -1,0 +1,76 @@
+# How to generate the data
+
+This documents the Gravity console snippets that were used to generate the
+datasets that go into this experiments data directory:
+
+- `17-infinite-discovery/data/artworks.json`
+
+These files are gitignored due to their size and currently live in a shared
+drive instead:
+
+- https://drive.google.com/drive/u/1/folders/1Lh7msUc0R_JlpNEzApZ4YbqB8x5tbpws
+
+The files were generated via the following Ruby snippets which were entered
+directly into a Gravity Rails console.
+
+## Choose collections
+
+For a large-ish dataset (a few thousand works), select all manually curated
+collections:
+
+```ruby
+collections = CuratedMarketingCollection.pluck(:id)
+```
+
+## Select artworks and their associated artists and partners
+
+```ruby
+# artworks
+artworks = collections.map{ |id|
+  MarketingCollection.find(id).artworks.published.for_sale
+}.flatten.uniq.compact
+```
+
+## Serialize the artworks
+
+Here we opt to use collector-facing terminology rather than Artsy internal
+jargon, on the assumption that this would perform better with the embedding
+models. For example:
+
+- attribution_class → **rarity**
+- category → **medium**
+- medium → **materials**
+- genes → **categories**
+- etc.
+
+We also keep some basic info about the associated artists and partners.
+
+We don't necessarily expect to index all of this data onto artworks, but it is
+included so that we have the option to do so, or to build up references to
+objects in other collections.
+
+```ruby
+# artworks json
+puts JSON.pretty_generate(artworks.map do |w|
+  {
+    id: w.id,
+    slug: w.slug,
+    title: w.title,
+    date: w.date,
+    rarity: w.attribution_class,
+    medium: w.category,
+    materials: w.medium,
+    list_price_amount: w.price_listed,
+    list_price_currency: w.price_currency,
+    categories: w.total_genome.without("Art", "Career Stage Gene").select{ |k,v| k !~ /(galleries based|made in)/i && v == 100}.keys,
+    tags: w.tags + w.auto_tags,
+    additional_information: w.additional_information,
+    image_url: w.default_image.image_urls['large'],
+    colors: w.colors,
+    artist_name: w.artists.first&.name,
+    artist_nationality: w.artists.first&.nationality,
+    artist_birthday: w.artists.first&.birthday,
+    artist_gender: w.artists.first&.gender,
+  }
+end)
+```

--- a/src/17-infinite-discovery/data.md
+++ b/src/17-infinite-discovery/data.md
@@ -22,7 +22,7 @@ collections:
 collections = CuratedMarketingCollection.pluck(:id)
 ```
 
-## Select artworks and their associated artists and partners
+## Select artworks and their associated artists
 
 ```ruby
 # artworks
@@ -43,7 +43,7 @@ models. For example:
 - genes → **categories**
 - etc.
 
-We also keep some basic info about the associated artists and partners.
+We also keep some basic info about the associated artists.
 
 We don't necessarily expect to index all of this data onto artworks, but it is
 included so that we have the option to do so, or to build up references to

--- a/src/17-infinite-discovery/helpers.ts
+++ b/src/17-infinite-discovery/helpers.ts
@@ -1,0 +1,18 @@
+import { GravityArtwork } from "./types"
+import path from "path"
+import fs from "fs"
+
+/**
+ * Read artworks from a local JSON file
+ *
+ * The JSON file will be gitignored, but the data can
+ * be obtained from a shared folder, currently at:
+ *
+ * https://drive.google.com/drive/u/1/folders/1Lh7msUc0R_JlpNEzApZ4YbqB8x5tbpws
+ */
+export async function getArtworks() {
+  const filePath = path.join(__dirname, "./data/artworks.json")
+  const data = await fs.promises.readFile(filePath, "utf-8")
+  const artworks: GravityArtwork[] = JSON.parse(data)
+  return artworks
+}

--- a/src/17-infinite-discovery/types.ts
+++ b/src/17-infinite-discovery/types.ts
@@ -1,5 +1,27 @@
 export type ArtworksClassName = "InfiniteDiscoveryArtworks"
 
+export type GravityArtwork = {
+  id: string
+  slug: string
+  colors: string[]
+  title: string
+  date: string
+  rarity: string
+  medium: string
+  materials: string
+  price: string
+  list_price_amount: number
+  list_price_currency: string
+  categories: string[]
+  tags: string[]
+  additional_information: string
+  image_url: string
+  artist_name: string
+  artist_nationality: string
+  artist_birthday: string
+  artist_gender: string
+}
+
 export type UsersClassName = "InfiniteDiscoveryUsers"
 
 export type User = { internalID: string; name: string }


### PR DESCRIPTION
This PR iterates on #36. It does two things:

1. Add additional fields to the `InfiniteArtworkClass`. 
    - date
    - materials
    - tags
    - additional information
    - artist name
    - artist nationality
    - artist birthday
    - artists gender

2. Imports  `gravity` `MarketingCollection` artworks (~10,000) into `weaviate`.

@egdbear - I've already run the script and imported these, as I wanted them to be available to you to test against. 

Appreciate to @anandaroop for the still  helpful `gravity` commands to grab the subset of artworks.

[DIA-917]

[DIA-917]: https://artsyproduct.atlassian.net/browse/DIA-917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ