### PR TITLE
refactor: use seenArtworks instead of dislikedArtworks for infinite discovery user

### DIFF
--- a/src/17-infinite-discovery/01-user.ts
+++ b/src/17-infinite-discovery/01-user.ts
@@ -9,7 +9,7 @@ dotenv.config()
 
 // Constants
 const CLASS_NAME: UsersClassName = "InfiniteDiscoveryUsers"
-const USERS: User[] = [{ internalID: "1", name: "Jane Tester" }]
+const USERS: User[] = []
 const BATCH_SIZE: number = 10
 
 const client = weaviate.client({
@@ -49,10 +49,10 @@ async function prepareCollection(className: UsersClassName) {
           "Artworks liked by this user. Used to calculate the user's vector.",
       },
       {
-        name: "dislikedArtworks",
+        name: "seenArtworks",
         dataType: ["InfiniteDiscoveryArtworks"],
         description:
-          "Artworks disliked by this user. Used to filter the artworks from infinite discovery results.",
+          'Artworks this user has seen and not "liked". Should not be considered a negative signal.',
       },
     ],
   }


### PR DESCRIPTION
This PR updates the `InfiniteDiscoveryUsers` schema to rename `dislikedArtworks` to `seenArtworks`. This follows conversations with the design and product team that indicated we won't consider artworks that aren't liked to implicitly disliked. 

We do still need to track all seen artworks, however, to prevent showing the same artwork multiple times. 

### Migrations

To update the schema run:

```
yarn tsx src/17-infinite-discovery/01-user.ts
```

### Follow-up

Once this PR is applied and merged, we can merge the related metaphysics PR: https://github.com/artsy/metaphysics/pull/6161