### PR TITLE
feat: use multimodal vectorizer for infinite discovery artworks

### DIFF
--- a/src/17-infinite-discovery/03-artworks-mutli2vec.ts
+++ b/src/17-infinite-discovery/03-artworks-mutli2vec.ts
@@ -1,0 +1,183 @@
+import weaviate, { generateUuid5 } from "weaviate-ts-client"
+import _ from "lodash"
+import { GravityArtwork } from "./types"
+import { deleteIfExists } from "system/weaviate"
+import dotenv from "dotenv"
+import { getArtworks, getImageDataForArtworks } from "./helpers"
+
+dotenv.config()
+
+const CLASS_NAME = "InfiniteDiscoveryArtworks"
+const BATCH_SIZE = 2
+
+const client = weaviate.client({
+  host: process.env.WEAVIATE_URL!,
+})
+
+async function main() {
+  await deleteIfExists(CLASS_NAME)
+  await prepareArtworkCollection()
+  const artworks = await getArtworks()
+  await insertArtworks(artworks)
+}
+
+/**
+ * Create and configure a new collection to hold artworks
+ */
+async function prepareArtworkCollection() {
+  const classWithProps = {
+    class: CLASS_NAME,
+    vectorizer: "multi2vec-clip",
+    moduleConfig: {
+      "multi2vec-clip": {
+        textFields: [
+          "title",
+          "medium",
+          "materials",
+          "categories",
+          "tags",
+          "additionalInformation",
+        ],
+        imageFields: ["image"],
+      },
+    },
+    properties: [
+      {
+        name: "internalID",
+        dataType: ["text"],
+      },
+      {
+        name: "rarity",
+        dataType: ["text"],
+      },
+      {
+        name: "medium",
+        dataType: ["text"],
+      },
+      {
+        name: "colors",
+        dataType: ["text[]"],
+      },
+      {
+        name: "slug",
+        dataType: ["text"],
+      },
+      {
+        name: "url",
+        dataType: ["text"],
+      },
+      {
+        name: "title",
+        dataType: ["text"],
+      },
+      {
+        name: "imageUrl",
+        dataType: ["text"],
+      },
+      {
+        name: "listPriceAmount",
+        dataType: ["number"],
+      },
+      {
+        name: "listPriceCurrency",
+        dataType: ["text"],
+      },
+      {
+        name: "date",
+        dataType: ["text"],
+      },
+      {
+        name: "materials",
+        dataType: ["text"],
+      },
+      {
+        name: "tags",
+        dataType: ["text[]"],
+      },
+      {
+        name: "additionalInformation",
+        dataType: ["text"],
+      },
+      {
+        name: "artistName",
+        dataType: ["text"],
+      },
+      {
+        name: "artistNationality",
+        dataType: ["text"],
+      },
+      {
+        name: "artistBirthday",
+        dataType: ["text"],
+      },
+      {
+        name: "artistGender",
+        dataType: ["text"],
+      },
+    ],
+  }
+
+  const classResult = await client.schema
+    .classCreator()
+    .withClass(classWithProps)
+    .do()
+
+  console.log(JSON.stringify(classResult, null, 2))
+}
+
+/**
+ * Insert artworks into Weaviate
+ *
+ * Also assigns a deterministic UUID to each artwork,
+ * based on its Gravity ID
+ */
+async function insertArtworks(
+  artworks: GravityArtwork[],
+  batchSize: number = BATCH_SIZE
+) {
+  console.log(`Inserting artwork: ${artworks.length}`)
+
+  const batches = _.chunk(artworks, batchSize)
+  console.log(`Inserting ${batches.length} batches`)
+
+  for (const artworkBatch of batches) {
+    const imageData = await getImageDataForArtworks(artworkBatch)
+
+    let batcher = client.batch.objectsBatcher()
+    batcher = batcher.withObjects(
+      ...artworkBatch.map((artwork) => {
+        return {
+          class: CLASS_NAME,
+          properties: {
+            internalID: artwork.id,
+            slug: artwork.slug,
+            title: artwork.title,
+            date: artwork.date,
+            rarity: artwork.rarity,
+            medium: artwork.medium,
+            materials: artwork.materials,
+            listPriceAmount: artwork.list_price_amount,
+            listPriceCurrency: artwork.list_price_currency,
+            categories: artwork.categories,
+            tags: artwork.tags,
+            additionalInformation: artwork.additional_information,
+            imageUrl: artwork.image_url,
+            colors: artwork.colors,
+            artistName: artwork.artist_name,
+            artistNationality: artwork.artist_nationality,
+            artistBirthday: artwork.artist_birthday,
+            artistGender: artwork.artist_gender,
+            image: imageData[artwork.id],
+          },
+          id: generateUuid5(artwork.id),
+        }
+      })
+    )
+    process.stdout.write(".")
+    await batcher.do()
+  }
+  process.stdout.write("\n")
+  console.log("Done.")
+}
+
+main().catch(console.error)

--- a/src/17-infinite-discovery/helpers.ts
+++ b/src/17-infinite-discovery/helpers.ts
@@ -1,7 +1,7 @@
 import { GravityArtwork } from "./types"
 import path from "path"
 import fs from "fs"
-import _ from "lodash"
+import { fromPairs, defaults } from "lodash"
 
 /**
  * Read artworks from a local JSON file

--- a/src/17-infinite-discovery/helpers.ts
+++ b/src/17-infinite-discovery/helpers.ts
@@ -1,6 +1,7 @@
 import { GravityArtwork } from "./types"
 import path from "path"
 import fs from "fs"
+import _ from "lodash"
 
 /**
  * Read artworks from a local JSON file
@@ -15,4 +16,62 @@ export async function getArtworks() {
   const data = await fs.promises.readFile(filePath, "utf-8")
   const artworks: GravityArtwork[] = JSON.parse(data)
   return artworks
+}
+
+/**
+ * Return a mapping of artwork ids to their respective image contents
+ * as Base64-encoded strings.
+ *
+ * @param artworkBatch - an array of artwork objects
+ * @returns a dictionary of artwork IDs and their Base64 encoded images
+ */
+export async function getImageDataForArtworks(
+  artworks: GravityArtwork[]
+): Promise<{ [key: string]: string }> {
+  const imageFieldPairs = await Promise.all(
+    artworks.map(async (artwork) => {
+      const resizedImageUrl = resizeImage(artwork.image_url)
+      const image = await getBase64Blob(resizedImageUrl)
+      return [artwork.id, image]
+    })
+  )
+  const imageData = _.fromPairs(imageFieldPairs)
+  return imageData
+}
+
+/**
+ * Generate an url for a resized, cached version of an image.
+ *
+ * Makes use of Gemini's crop endpoint (media.artsy.net/crop) to
+ * resize the image to fit the desired width and height.
+ *
+ * The actual request is issued to the Cloudfront distribution,
+ * so that the resized image is cached and served from the CDN.
+ *
+ * @param src URL of the original image
+ * @param options.width (optional) desired width of the resized image, defaults to 512
+ * @param options.height (optional) desired height of the resized image, defaults to 512
+ * @returns
+ */
+export function resizeImage(
+  src: string,
+  options?: {
+    width: number
+    height: number
+  }
+) {
+  const { width, height } = _.defaults(options, { width: 500, height: 500 })
+  return `https://d7hftxdivxxvm.cloudfront.net/?src=${src}&resize_to=fit&width=${width}&height=${height}&grow=false`
+}
+
+/**
+ * Read an image over the network and convert it to a base64 string
+ *
+ * @param imageUrl URL of the image to read
+ * @returns Base64 encoded image data
+ */
+export async function getBase64Blob(imageUrl: string): Promise<string | null> {
+  const response = await fetch(imageUrl)
+  const buffer = await response.arrayBuffer()
+  return Buffer.from(buffer).toString("base64")
 }


### PR DESCRIPTION
This PR adds another implementation to the infinite discovery embeddings. Specifically, it uses a multi-modal vectorizer ([multi2vec](https://weaviate.io/developers/weaviate/model-providers/transformers/embeddings-multimodal)), which allows us to include the artwork image in the embedding. 

This approach also utilizes a [self-hosted vectorizer](https://github.com/artsy/substance/pull/388), rather than directly hitting the openai embedding api. The model is [pulled from hugging face](https://huggingface.co/sentence-transformers/clip-ViT-B-32-multilingual-v1). 