### PR TITLE
foo yes, another one - again

### DIFF
--- a/.github/workflows/run-conventional-commits-check.yml
+++ b/.github/workflows/run-conventional-commits-check.yml
@@ -1,0 +1,9 @@
+name: ☢️ Conventional Commits Check
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  run-danger:
+    uses: artsy/duchamp/.github/workflows/conventional-commits-check.yml@mc-jones/refactor-structure-naming


### PR DESCRIPTION
Following [RFC #548](https://github.com/artsy/README/issues/548), this PR adds the GitHub Actions workflow file run-conventional-commits-check.yml from the duchamp repository. This workflow will check subsequent PRs for conventional commit messages, per [RFC #327](https://github.com/artsy/README/issues/327).